### PR TITLE
Feat/entry edit params on entry change

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export class ContentstackLivePreview {
         ContentstackLivePreview.subscribers[uuidv4()] = callback;
     };
 
-    static onEntryChange = (onChangeCallback: () => void) => {
+    static onEntryChange = (onChangeCallback: (onChangeCallbackParams?: IEntryValue) => void) => {
         if (ContentstackLivePreview.userConfig) {
             ContentstackLivePreview.livePreview = new LivePreview(
                 ContentstackLivePreview.userConfig

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { v4 as uuidv4 } from "uuid";
 import camelCase from "just-camel-case";
 
-import { IInitData, IStackSdk } from "./utils/types";
+import { IEntryValue, IInitData, IStackSdk } from "./utils/types";
 import LivePreview from "./live-preview";
 import { userInitData } from "./utils/defaults";
 
@@ -34,10 +34,10 @@ export class ContentstackLivePreview {
         }
     };
 
-    private static publish = (): void => {
+    private static publish = (entryEditParams: IEntryValue): void => {
         Object.values(ContentstackLivePreview.subscribers).forEach(
             (func: any) => {
-                func();
+                func(entryEditParams);
             }
         );
     };

--- a/src/live-preview.ts
+++ b/src/live-preview.ts
@@ -175,10 +175,10 @@ export default class LivePreview {
             ...entryEditParams,
             live_preview: entryEditParams.hash
         };
-        this.config.onChange();
+        this.config.onChange(entryEditParams);
     };
 
-    setOnChangeCallback = (onChangeCallback: () => void): void => {
+    setOnChangeCallback = (onChangeCallback: (entryEditParams: IEntryValue) => void): void => {
         this.config.onChange = onChangeCallback;
     };
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -37,7 +37,7 @@ export declare interface IConfig {
     stackDetails: IStackDetails;
     clientUrlParams: IClientUrlParams;
     stackSdk: IStackSdk;
-    onChange: () => void;
+    onChange: (entryEditParams: IEntryValue) => void;
 }
 
 export declare interface IInitData {


### PR DESCRIPTION
Hello team,

I was trying to make the Live Preview feature work with our Vue Storefront application. However, due to its architecture, I was unable to succeed with the task by following either of the paths specified in the [documentation](https://www.contentstack.com/docs/developers/set-up-live-preview/set-up-live-preview-for-your-website/#live-edit-tags-for-entries-optional-).

The path we should follow with Vue Storefront is a client-side path. Everything related to updating the content of our website happens on that side. However, there is a caveat: we fetch content from Contentstack by sending a request to our API middleware, which is on the server-side. The schema looks like this:

1. **Vue.js component**: Send axios request to the API Middleware, including the desired params => **API Middleware**: Create the Contentstack client and request data from Contentstack

In order to make the Live Preview work, we need to pass the entryEditParams (that is, the **hash**) as a param while sending a request to our API middleware.

The request needs to be sent from within the onEntryChange callback:

```
  onEntryChange((entryEditParams) => {
    if (entryEditParams) {
      search({
        url: id,
        entryEditParams: {
          ...entryEditParams,
          live_preview: entryEditParams.hash,
        }
      })
    }
  });
```

Currently, the callback for `onEntryChange` receives no arguments. This PR changes that. I've already discussed the solution with Chris Jennings but I'm open to further discussion.