### PR TITLE
Feat/entry edit params on entry change

### DIFF
--- a/src/contentstack-live-preview-HOC.ts
+++ b/src/contentstack-live-preview-HOC.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import camelCase from "just-camel-case";
 
 import {
+    IEntryValue,
     IInitData,
     IStackSdk,
     OnEntryChangeCallback,
@@ -39,11 +40,11 @@ export class ContentstackLivePreview {
         }
     }
 
-    private static publish(): void {
+    private static publish(entryEditParams: IEntryValue): void {
         Object.values<OnEntryChangeCallback>(
             ContentstackLivePreview.subscribers
         ).forEach((func) => {
-            func();
+            func(entryEditParams);
         });
     }
 

--- a/src/contentstack-live-preview-HOC.ts
+++ b/src/contentstack-live-preview-HOC.ts
@@ -40,7 +40,7 @@ export class ContentstackLivePreview {
         }
     }
 
-    private static publish(entryEditParams: IEntryValue): void {
+    private static publish(entryEditParams?: IEntryValue): void {
         Object.values<OnEntryChangeCallback>(
             ContentstackLivePreview.subscribers
         ).forEach((func) => {

--- a/src/live-preview.ts
+++ b/src/live-preview.ts
@@ -222,10 +222,10 @@ export default class LivePreview {
             ...entryEditParams,
             live_preview: entryEditParams.hash,
         };
-        this.config.onChange();
-    }
+        this.config.onChange(entryEditParams);
+    };
 
-    setOnChangeCallback(onChangeCallback: () => void): void {
+    setOnChangeCallback = (onChangeCallback: (entryEditParams: IEntryValue) => void): void => {
         this.config.onChange = onChangeCallback;
     }
 

--- a/src/live-preview.ts
+++ b/src/live-preview.ts
@@ -223,9 +223,9 @@ export default class LivePreview {
             live_preview: entryEditParams.hash,
         };
         this.config.onChange(entryEditParams);
-    };
+    }
 
-    setOnChangeCallback = (onChangeCallback: (entryEditParams: IEntryValue) => void): void => {
+    setOnChangeCallback = (onChangeCallback: (entryEditParams?: IEntryValue) => void): void => {
         this.config.onChange = onChangeCallback;
     }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -30,6 +30,11 @@ export declare interface IInitStackDetails {
     apiKey: string;
     environment: string;
 }
+
+export declare type OnEntryChangeCallback = (entryEditParams?: IEntryValue) => void;
+
+export declare type OnEntryChangeCallbackUID = string;
+
 export declare interface IConfig {
     ssr: boolean;
     enable: boolean;
@@ -37,7 +42,7 @@ export declare interface IConfig {
     stackDetails: IStackDetails;
     clientUrlParams: IClientUrlParams;
     stackSdk: IStackSdk;
-    onChange: () => void;
+    onChange: OnEntryChangeCallback
 }
 
 export declare interface IInitData {
@@ -48,7 +53,3 @@ export declare interface IInitData {
     clientUrlParams: Partial<Omit<IClientUrlParams, "url">>;
     stackSdk: IStackSdk;
 }
-
-export declare type OnEntryChangeCallback = () => void;
-
-export declare type OnEntryChangeCallbackUID = string;


### PR DESCRIPTION
Hello team,

I was trying to make the Live Preview feature work with our Vue Storefront application. However, due to its architecture, I was unable to succeed with the task by following either of the paths specified in the [documentation](https://www.contentstack.com/docs/developers/set-up-live-preview/set-up-live-preview-for-your-website/#live-edit-tags-for-entries-optional-).

The path we should follow with Vue Storefront is a client-side path. Everything related to updating the content of our website happens on that side. However, there is a caveat: we fetch content from Contentstack by sending a request to our API middleware, which is on the server-side. The schema looks like this:

1. **Vue.js component**: Send axios request to the API Middleware, including the desired params => **API Middleware**: Create the Contentstack client and request data from Contentstack

In order to make the Live Preview work, we need to pass the entryEditParams (that is, the **hash**) as a param while sending a request to our API middleware.

The request needs to be sent from within the onEntryChange callback:

```
  onEntryChange((entryEditParams) => {
    if (entryEditParams) {
      search({
        url: id,
        entryEditParams: {
          ...entryEditParams,
          live_preview: entryEditParams.hash,
        }
      })
    }
  });
```

Currently, the callback for `onEntryChange` receives no arguments. This PR changes that. I've already discussed the solution with Chris Jennings but I'm open to further discussion.