### PR TITLE
feat: handle add buttons during multiple

### DIFF
--- a/src/liveEditor/utils/__test__/generateStartEditingButton.test.ts
+++ b/src/liveEditor/utils/__test__/generateStartEditingButton.test.ts
@@ -1,7 +1,7 @@
-import { getDefaultConfig } from "../../utils/defaults";
-import { PublicLogger } from "../../utils/public-logger";
-import { IConfig } from "../../types/types";
-import { generateStartEditingButton } from "./generateStartEditingButton";
+import { getDefaultConfig } from "../../../utils/defaults";
+import { PublicLogger } from "../../../utils/public-logger";
+import { IConfig } from "../../../types/types";
+import { generateStartEditingButton } from "../generateStartEditingButton";
 
 describe("generateStartEditingButton", () => {
     let config: IConfig;

--- a/src/liveEditor/utils/__test__/multipleElementAddButton.test.ts
+++ b/src/liveEditor/utils/__test__/multipleElementAddButton.test.ts
@@ -1,0 +1,369 @@
+import {
+    generateAddButton,
+    getChildrenDirection,
+    handleAddButtonsForMultiple,
+    hideAddInstanceButtons,
+} from "../multipleElementAddButton";
+
+describe("generateAddButton", () => {
+    test("should generate a button", () => {
+        const button = generateAddButton();
+        expect(button.tagName).toBe("BUTTON");
+    });
+});
+
+describe("getChildrenDirection", () => {
+    let firstChild: HTMLElement;
+    let secondChild: HTMLElement;
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        firstChild = document.createElement("div");
+        firstChild.setAttribute(
+            "data-cslp",
+            "page.bltapikey.en-us.page_components.0.hero_banner"
+        );
+        firstChild.setAttribute(
+            "data-cslp-container",
+            "page.bltapikey.en-us.page_components"
+        );
+
+        secondChild = document.createElement("div");
+        secondChild.setAttribute(
+            "data-cslp",
+            "page.bltapikey.en-us.page_components.1.section"
+        );
+        secondChild.setAttribute(
+            "data-cslp-container",
+            "page.bltapikey.en-us.page_components"
+        );
+
+        container = document.createElement("div");
+        container.setAttribute(
+            "data-cslp",
+            "page.bltapikey.en-us.page_components"
+        );
+        container.appendChild(firstChild);
+        container.appendChild(secondChild);
+
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.getElementsByTagName("body")[0].innerHTML = "";
+        jest.resetAllMocks();
+    });
+
+    test(`should return "none" if it is not a list type`, () => {
+        container.innerHTML = "";
+
+        const direction = getChildrenDirection(firstChild);
+        expect(direction).toBe("none");
+    });
+
+    test(`should return "none" if the parent container is not found`, () => {
+        container.removeAttribute("data-cslp");
+        expect(getChildrenDirection(firstChild)).toBe("none");
+    });
+
+    test("should return 'vertical' if the parent container is found and the children are in a vertical list", () => {
+        expect(getChildrenDirection(firstChild)).toBe("vertical");
+    });
+
+    test("should return 'horizontal' if the parent container is found and the children are in a horizontal list", () => {
+        firstChild.getBoundingClientRect = jest.fn().mockReturnValue({
+            left: 10,
+            top: 10,
+        });
+
+        secondChild.getBoundingClientRect = jest.fn().mockReturnValue({
+            left: 20,
+            top: 10,
+        });
+
+        expect(getChildrenDirection(firstChild)).toBe("horizontal");
+    });
+
+    test("should create a clone and determine direction when one child is present", () => {
+        container.removeChild(secondChild);
+
+        firstChild.getBoundingClientRect = jest.fn().mockReturnValue({
+            left: -10,
+            top: 10,
+        });
+
+        expect(getChildrenDirection(firstChild)).toBe("vertical");
+    });
+
+    test("should return 'none' if input is not provided", () => {
+        // @ts-ignore
+        expect(getChildrenDirection()).toBe("none");
+    });
+
+    test(`should return "none" if container does not contain the elements`, () => {
+        container.innerHTML = "";
+        document.body.appendChild(firstChild);
+        document.body.appendChild(secondChild);
+
+        expect(getChildrenDirection(firstChild)).toBe("none");
+    });
+});
+
+describe("handleAddButtonsForMultiple", () => {
+    let firstChild: HTMLElement;
+    let secondChild: HTMLElement;
+    let container: HTMLElement;
+    let visualEditorWrapper: HTMLElement;
+    let previousButton: HTMLButtonElement;
+    let nextButton: HTMLButtonElement;
+
+    beforeEach(() => {
+        firstChild = document.createElement("div");
+        firstChild.setAttribute(
+            "data-cslp",
+            "page.bltapikey.en-us.page_components.0.hero_banner"
+        );
+        firstChild.setAttribute(
+            "data-cslp-container",
+            "page.bltapikey.en-us.page_components"
+        );
+
+        secondChild = document.createElement("div");
+        secondChild.setAttribute(
+            "data-cslp",
+            "page.bltapikey.en-us.page_components.1.section"
+        );
+        secondChild.setAttribute(
+            "data-cslp-container",
+            "page.bltapikey.en-us.page_components"
+        );
+
+        firstChild.getBoundingClientRect = jest.fn().mockReturnValue({
+            left: 10,
+            right: 20,
+            top: 10,
+            bottom: 20,
+        });
+
+        secondChild.getBoundingClientRect = jest.fn().mockReturnValue({
+            left: 20,
+            right: 30,
+            top: 10,
+            bottom: 20,
+        });
+
+        previousButton = document.createElement("button");
+        nextButton = document.createElement("button");
+
+        visualEditorWrapper = document.createElement("div");
+
+        container = document.createElement("div");
+        container.setAttribute(
+            "data-cslp",
+            "page.bltapikey.en-us.page_components"
+        );
+        container.appendChild(firstChild);
+        container.appendChild(secondChild);
+
+        document.body.appendChild(container);
+        document.body.appendChild(visualEditorWrapper);
+    });
+
+    afterEach(() => {
+        document.getElementsByTagName("body")[0].innerHTML = "";
+        jest.resetAllMocks();
+    });
+
+    test("should not add buttons if the editable element is not found", () => {
+        handleAddButtonsForMultiple({
+            editableElement: null,
+            visualEditorWrapper,
+            nextButton: nextButton,
+            previousButton: previousButton,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeFalsy();
+    });
+
+    test("should not add buttons if the editable element does not contain container", () => {
+        firstChild.removeAttribute("data-cslp-container");
+
+        handleAddButtonsForMultiple({
+            editableElement: firstChild,
+            visualEditorWrapper,
+            nextButton: nextButton,
+            previousButton: previousButton,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeFalsy();
+    });
+
+    test("should not add buttons if the direction is none", () => {
+        container.removeAttribute("data-cslp");
+        handleAddButtonsForMultiple({
+            editableElement: firstChild,
+            visualEditorWrapper,
+            nextButton: nextButton,
+            previousButton: previousButton,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeFalsy();
+    });
+
+    test("should not add buttons if the visual editor wrapper is not found", () => {
+        handleAddButtonsForMultiple({
+            editableElement: firstChild,
+            visualEditorWrapper: null,
+            nextButton: nextButton,
+            previousButton: previousButton,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeFalsy();
+    });
+
+    test("should append the buttons to the visual editor wrapper", () => {
+        handleAddButtonsForMultiple({
+            editableElement: firstChild,
+            visualEditorWrapper,
+            nextButton: nextButton,
+            previousButton: previousButton,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeTruthy();
+        expect(visualEditorWrapper.contains(nextButton)).toBeTruthy();
+    });
+
+    test("should add the buttons to the center if the direction is horizontal", () => {
+        handleAddButtonsForMultiple({
+            editableElement: firstChild,
+            visualEditorWrapper,
+            nextButton: nextButton,
+            previousButton: previousButton,
+        });
+
+        expect(previousButton.style.left).toBe("10px");
+        expect(previousButton.style.top).toBe("15px");
+
+        expect(nextButton.style.left).toBe("20px");
+        expect(nextButton.style.top).toBe("15px");
+    });
+
+    test("should add the buttons to the middle if the direction is vertical", () => {
+        firstChild.getBoundingClientRect = jest.fn().mockReturnValue({
+            left: 10,
+            right: 20,
+            top: 10,
+            bottom: 20,
+        });
+
+        secondChild.getBoundingClientRect = jest.fn().mockReturnValue({
+            left: 10,
+            right: 20,
+            top: 20,
+            bottom: 30,
+        });
+        handleAddButtonsForMultiple({
+            editableElement: firstChild,
+            visualEditorWrapper,
+            nextButton: nextButton,
+            previousButton: previousButton,
+        });
+
+        expect(previousButton.style.left).toBe("15px");
+        expect(previousButton.style.top).toBe("10px");
+
+        expect(nextButton.style.left).toBe("15px");
+        expect(nextButton.style.top).toBe("20px");
+    });
+});
+
+describe("hideAddInstanceButtons", () => {
+    let visualEditorWrapper: HTMLDivElement;
+    let previousButton: HTMLButtonElement;
+    let nextButton: HTMLButtonElement;
+    let overlayWrapper: HTMLDivElement;
+    let eventTarget: EventTarget;
+
+    beforeEach(() => {
+        visualEditorWrapper = document.createElement("div");
+        previousButton = document.createElement("button");
+        nextButton = document.createElement("button");
+        overlayWrapper = document.createElement("div");
+        eventTarget = document.createElement("div");
+
+        visualEditorWrapper.appendChild(previousButton);
+        visualEditorWrapper.appendChild(nextButton);
+
+        document.body.appendChild(visualEditorWrapper);
+        document.body.appendChild(overlayWrapper);
+    });
+
+    afterEach(() => {
+        document.getElementsByTagName("body")[0].innerHTML = "";
+        jest.resetAllMocks();
+    });
+
+    test("should not hide buttons if wrapper or buttons are not present", () => {
+        hideAddInstanceButtons({
+            visualEditorWrapper: null,
+            eventTarget: eventTarget,
+            nextButton: null,
+            previousButton: null,
+            overlayWrapper: overlayWrapper,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeTruthy();
+        expect(visualEditorWrapper.contains(nextButton)).toBeTruthy();
+    });
+
+    test("should not hide buttons if previous button contains event target", () => {
+        hideAddInstanceButtons({
+            visualEditorWrapper: visualEditorWrapper,
+            eventTarget: previousButton,
+            nextButton: nextButton,
+            previousButton: previousButton,
+            overlayWrapper: overlayWrapper,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeTruthy();
+        expect(visualEditorWrapper.contains(nextButton)).toBeTruthy();
+
+        hideAddInstanceButtons({
+            visualEditorWrapper: visualEditorWrapper,
+            eventTarget: nextButton,
+            nextButton: nextButton,
+            previousButton: previousButton,
+            overlayWrapper: overlayWrapper,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeTruthy();
+        expect(visualEditorWrapper.contains(nextButton)).toBeTruthy();
+    });
+    test("should not hide buttons if next button contains event target", () => {
+        overlayWrapper.classList.add("visible");
+
+        hideAddInstanceButtons({
+            visualEditorWrapper: visualEditorWrapper,
+            eventTarget: eventTarget,
+            nextButton: nextButton,
+            previousButton: previousButton,
+            overlayWrapper: overlayWrapper,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeTruthy();
+        expect(visualEditorWrapper.contains(nextButton)).toBeTruthy();
+    });
+
+    test("should hide the buttons", () => {
+        hideAddInstanceButtons({
+            visualEditorWrapper: visualEditorWrapper,
+            eventTarget: eventTarget,
+            nextButton: nextButton,
+            previousButton: previousButton,
+            overlayWrapper: overlayWrapper,
+        });
+
+        expect(visualEditorWrapper.contains(previousButton)).toBeFalsy();
+        expect(visualEditorWrapper.contains(nextButton)).toBeFalsy();
+    });
+});

--- a/src/liveEditor/utils/multipleElementAddButton.ts
+++ b/src/liveEditor/utils/multipleElementAddButton.ts
@@ -1,0 +1,157 @@
+const cssReset =
+    "overflow: hidden !important; width: 0 !important; height: 0 !important; padding: 0 !important; border: 0 !important;";
+
+const plusIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">\n<path d="M10.4688 4.375C10.4688 4.11612 10.259 3.90625 10.0001 3.90625C9.74121 3.90625 9.53135 4.11612 9.53135 4.375V9.27307H4.37402C4.11514 9.27307 3.90527 9.48294 3.90527 9.74182C3.90527 10.0007 4.11514 10.2106 4.37402 10.2106H9.53135V15.625C9.53135 15.8839 9.74121 16.0937 10.0001 16.0937C10.259 16.0937 10.4688 15.8839 10.4688 15.625V10.2106H15.6259C15.8847 10.2106 16.0946 10.0007 16.0946 9.74182C16.0946 9.48294 15.8847 9.27307 15.6259 9.27307H10.4688V4.375Z" fill="#475161"/>\n</svg>`;
+
+export function getChildrenDirection(
+    editableElement: Element
+): "none" | "horizontal" | "vertical" {
+    if (!editableElement) {
+        return "none";
+    }
+
+    const parentCSLPValue = editableElement.getAttribute("data-cslp-container");
+    const parentElement = editableElement.closest(
+        `[data-cslp="${parentCSLPValue}"]`
+    );
+
+    if (!parentElement) {
+        return "none";
+    }
+
+    const children = parentElement.querySelectorAll(
+        `[data-cslp-container="${parentCSLPValue}"]`
+    );
+    const firstChildElement = children[0];
+    let secondChildElement = children[1];
+    let firstChildClone: HTMLDivElement | undefined = undefined;
+
+    // create a clone to check its position relative to first child
+    if (!secondChildElement) {
+        firstChildClone = document.createElement("div");
+        firstChildClone.setAttribute(
+            "class",
+            firstChildElement.getAttribute("class") ?? ""
+        );
+        firstChildClone.setAttribute("style", cssReset);
+        parentElement.appendChild(firstChildClone);
+        secondChildElement = firstChildClone;
+    }
+
+    // get horizontal and vertical position differences
+    const firstChildBounds = firstChildElement.getBoundingClientRect();
+    const secondChildBounds = secondChildElement.getBoundingClientRect();
+
+    const deltaX = Math.abs(firstChildBounds.left - secondChildBounds.left);
+    const deltaY = Math.abs(firstChildBounds.top - secondChildBounds.top);
+
+    const dir = deltaX > deltaY ? "horizontal" : "vertical";
+
+    if (firstChildClone) {
+        parentElement?.removeChild(firstChildClone);
+    }
+
+    return dir;
+}
+
+export function generateAddButton(): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.innerHTML = plusIcon;
+    button.classList.add("visual-editor__add-button");
+    return button;
+}
+
+export function handleAddButtonsForMultiple(elements: {
+    editableElement: Element | null;
+    visualEditorWrapper: HTMLElement | null;
+    previousButton: HTMLButtonElement;
+    nextButton: HTMLButtonElement;
+}): void {
+    const { editableElement, visualEditorWrapper, previousButton, nextButton } =
+        elements;
+
+    if (
+        !editableElement ||
+        !editableElement.getAttribute("data-cslp-container")
+    ) {
+        return;
+    }
+
+    const direction = getChildrenDirection(editableElement);
+
+    if (direction === "none" || !visualEditorWrapper) {
+        return;
+    }
+
+    const targetDOMDimension = editableElement.getBoundingClientRect();
+
+    if (!visualEditorWrapper.contains(previousButton)) {
+        visualEditorWrapper.appendChild(previousButton);
+    }
+
+    if (!visualEditorWrapper.contains(nextButton)) {
+        visualEditorWrapper.appendChild(nextButton);
+    }
+
+    if (direction === "horizontal") {
+        const middleHeight =
+            targetDOMDimension.top +
+            (targetDOMDimension.bottom - targetDOMDimension.top) / 2 +
+            window.scrollY;
+        previousButton.style.left = `${targetDOMDimension.left}px`;
+        previousButton.style.top = `${middleHeight}px`;
+
+        nextButton.style.left = `${targetDOMDimension.right}px`;
+        nextButton.style.top = `${middleHeight}px`;
+    } else {
+        const middleWidth =
+            targetDOMDimension.left +
+            (targetDOMDimension.right - targetDOMDimension.left) / 2;
+        previousButton.style.left = `${middleWidth}px`;
+        previousButton.style.top = `${
+            targetDOMDimension.top + window.scrollY
+        }px`;
+
+        nextButton.style.left = `${middleWidth}px`;
+        nextButton.style.top = `${
+            targetDOMDimension.bottom + window.scrollY
+        }px`;
+    }
+}
+
+export function hideAddInstanceButtons(elements: {
+    visualEditorWrapper: HTMLDivElement | null;
+    previousButton: HTMLButtonElement | null;
+    nextButton: HTMLButtonElement | null;
+    overlayWrapper: HTMLDivElement | null;
+    eventTarget: EventTarget | null;
+}): void {
+    const {
+        visualEditorWrapper,
+        nextButton,
+        overlayWrapper,
+        previousButton,
+        eventTarget,
+    } = elements;
+
+    if (!visualEditorWrapper || !previousButton || !nextButton) {
+        return;
+    }
+    if (
+        eventTarget &&
+        (previousButton.contains(eventTarget as Node) ||
+            nextButton.contains(eventTarget as Node))
+    ) {
+        return;
+    }
+    if (overlayWrapper?.classList.contains("visible")) {
+        return;
+    }
+    if (visualEditorWrapper.contains(previousButton)) {
+        visualEditorWrapper.removeChild(previousButton);
+    }
+
+    if (visualEditorWrapper.contains(nextButton)) {
+        visualEditorWrapper.removeChild(nextButton);
+    }
+}


### PR DESCRIPTION
This PR will add a function to add plus buttons in multiple type fields like group and modular blocks. Additionally, it will move a test file to its correct folder.

# QA

Here is the list of tests performed
- generateAddButton
  - should generate a button
- getChildrenDirection
  - should return "none" if it is not a list type
  - should return "none" if the parent container is not found
  - should return 'vertical' if the parent container is found and the children are in a vertical list
  - should return 'horizontal' if the parent container is found and the children are in a horizontal list
  - should create a clone and determine direction when one child is present
  - should return 'none' if the input is not provided
  - should return "none" if the container does not contain the elements
- handleAddButtonsForMultiple
  - should not add buttons if the editable element is not found
  - should not add buttons if the editable element does not contain a container
  - should not add buttons if the direction is none
  - should not add buttons if the visual editor wrapper is not found
  - should append the buttons to the visual editor wrapper
  - should add the buttons to the center if the direction is horizontal
  - should add the buttons to the middle, if the direction is vertical
- hideAddInstanceButtons
  - should not hide buttons if wrapper or buttons are not present
  - should not hide buttons if the previous button contains the event target
  - should not hide buttons if the next button contains the event target
  - should hide the buttons

fixes: https://contentstack.atlassian.net/browse/VC-180