### PR TITLE
feat: add locale support for visual editor

### DIFF
--- a/src/__test__/contentstack-live-preview-HOC.test.ts
+++ b/src/__test__/contentstack-live-preview-HOC.test.ts
@@ -3,7 +3,6 @@ import { PublicLogger } from "../utils/public-logger";
 import { IInitData } from "../types/types";
 import { sendPostmessageToWindow } from "./utils";
 import packageJson from "../../package.json";
-const ContentstackLivePreview2 = ContentstackLivePreview;
 
 describe("Live preview HOC Callback Pub Sub", () => {
     afterEach(() => {

--- a/src/live-preview.ts
+++ b/src/live-preview.ts
@@ -38,6 +38,7 @@ export default class LivePreview {
         },
         mode: 1,
         stackDetails: {
+            locale: "en-us",
             apiKey: "",
             environment: "",
             contentTypeUid: "",

--- a/src/liveEditor/__test__/__snapshots__/index.test.ts.snap
+++ b/src/liveEditor/__test__/__snapshots__/index.test.ts.snap
@@ -151,6 +151,7 @@ exports[`Visual editor inline editing should add overlay to DOM when clicked 1`]
       data-cslp-app-host="https://app.contentstack.com:443"
       data-cslp-branch="main"
       data-cslp-environment=""
+      data-cslp-locale="en-us"
       data-cslp-stack=""
       data-testid="vcms-start-editing-btn"
     >
@@ -277,6 +278,7 @@ exports[`Visual editor on click, the sdk should do nothing if data-cslp not avai
       data-cslp-app-host="https://app.contentstack.com:443"
       data-cslp-branch="main"
       data-cslp-environment=""
+      data-cslp-locale="en-us"
       data-cslp-stack=""
       data-testid="vcms-start-editing-btn"
     >
@@ -368,6 +370,7 @@ exports[`Visual editor should append a visual editor container to the DOM 1`] = 
     data-cslp-app-host="https://app.contentstack.com:443"
     data-cslp-branch="main"
     data-cslp-environment=""
+    data-cslp-locale="en-us"
     data-cslp-stack=""
     data-testid="vcms-start-editing-btn"
   >

--- a/src/liveEditor/__test__/index.test.ts
+++ b/src/liveEditor/__test__/index.test.ts
@@ -184,7 +184,9 @@ describe("start editing button", () => {
     });
     afterEach(() => {
         document.getElementsByTagName("html")[0].innerHTML = "";
+        jest.restoreAllMocks();
     });
+
     test("should exist", () => {
         new VisualEditor(config);
         const startEditingButton = document.querySelector(
@@ -195,25 +197,43 @@ describe("start editing button", () => {
     });
 
     test("should go to an URL upon click", () => {
+        config.stackDetails.apiKey = "api_key";
+        config.stackDetails.environment = "environment";
+
+        const mockReplace = jest.fn();
+        Object.defineProperty(window, "location", {
+            value: {
+                assign: mockReplace,
+                href: "https://example.com",
+            },
+        });
+
         new VisualEditor(config);
         const startEditingButton = document.querySelector(
             `[data-testid="vcms-start-editing-btn"]`
         ) as HTMLButtonElement;
 
-        const mockReplace = jest.fn();
-        Object.defineProperty(window, "location", {
-            value: {
-                replace: mockReplace,
-            },
-        });
+        startEditingButton.click();
+
+        console.log(document.body.outerHTML);
+
+        expect(mockReplace).toHaveBeenCalled();
+        expect(mockReplace.mock.calls.at(0).at(0).toString()).toBe(
+            "https://app.contentstack.com/?branch=main&locale=en-us#!/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com"
+        );
+
+        const h1 = document.createElement("h1");
+        h1.setAttribute(
+            "data-cslp",
+            "all_fields.blt58a50b4cebae75c5.en-uk.title"
+        );
+
+        document.body.appendChild(h1);
 
         startEditingButton.click();
 
-        expect(mockReplace).toHaveBeenCalled();
-        expect(mockReplace).toHaveBeenCalledWith(
-            new URL(
-                "https://app.contentstack.com/#!/live-editor/stack//environment//target_url/undefined?branch=main"
-            )
+        expect(mockReplace.mock.calls.at(1).at(0).toString()).toBe(
+            "https://app.contentstack.com/?branch=main&locale=en-uk#!/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com"
         );
     });
 });

--- a/src/liveEditor/index.ts
+++ b/src/liveEditor/index.ts
@@ -21,6 +21,7 @@ import {
 import { addFocusOverlay, hideFocusOverlay } from "./utils/focusOverlayWrapper";
 import { getCsDataOfElement } from "./utils/getCsDataOfElement";
 import { ISchemaIndividualFieldMap } from "./utils/types/index.types";
+import { extractDetailsFromCslp } from "../utils/cslpdata";
 
 export class VisualEditor {
     private fieldSchemaMap: Record<string, ISchemaIndividualFieldMap> = {};
@@ -62,18 +63,34 @@ export class VisualEditor {
             "data-cslp-app-host"
         ) as string;
 
-        //TODO: Check if branch is mandatory
-        const searchParams = new URLSearchParams({
-            branch: branch,
-        });
         const completeURL = new URL(
             `/#!/live-editor/stack/${stack}/environment/${environment}/target_url/${encodeURIComponent(
                 window.location.href
-            )}?${searchParams.toString()}`,
+            )}`,
             app_url
         );
 
-        window.location.replace(completeURL);
+        completeURL.searchParams.set("branch", branch);
+
+        // get the locale from the data cslp attribute
+        const elementWithDataCslp = document.querySelector(`[data-cslp]`);
+
+        if (elementWithDataCslp) {
+            const cslpData = elementWithDataCslp.getAttribute(
+                "data-cslp"
+            ) as string;
+            const { locale } = extractDetailsFromCslp(cslpData);
+
+            completeURL.searchParams.set("locale", locale);
+        } else {
+            const locale = startEditingButton.getAttribute(
+                "data-cslp-locale"
+            ) as string;
+
+            completeURL.searchParams.set("locale", locale);
+        }
+
+        window.location.assign(completeURL.toString());
     };
 
     private handleMouseDownForVisualEditing = (event: MouseEvent): void => {

--- a/src/liveEditor/utils/generateStartEditingButton.ts
+++ b/src/liveEditor/utils/generateStartEditingButton.ts
@@ -13,7 +13,7 @@ export function generateStartEditingButton(
     visualEditorWrapper: HTMLDivElement | null,
     onClick: (event: MouseEvent) => void
 ): HTMLButtonElement | undefined {
-    const { apiKey, branch, environment } = config.stackDetails;
+    const { apiKey, branch, environment, locale } = config.stackDetails;
     const { url } = config.clientUrlParams;
 
     if (!visualEditorWrapper) {
@@ -28,6 +28,7 @@ export function generateStartEditingButton(
     startEditingButton.setAttribute("data-cslp-environment", environment);
     startEditingButton.setAttribute("data-cslp-branch", branch);
     startEditingButton.setAttribute("data-cslp-app-host", url);
+    startEditingButton.setAttribute("data-cslp-locale", locale);
     startEditingButton.setAttribute("data-testid", "vcms-start-editing-btn");
     startEditingButton.classList.add("visual-editor__start-editing-btn");
     startEditingButton.addEventListener("click", onClick);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,16 +31,30 @@ export declare interface IStackDetails {
     contentTypeUid: string;
     entryUid: string;
     branch: string;
+    /**
+     * This locale is currently used by the live editor to
+     * redirect to the correct locale if the no data-cslp tag
+     * is present in the HTML to extract the locale.
+     */
+    locale: string;
 }
 
 export declare interface IInitStackDetails {
     apiKey: string;
     environment: string;
     branch: string;
+    /**
+     * This locale is currently used by the live editor to
+     * redirect to the correct locale if the no data-cslp tag
+     * is present in the HTML to extract the locale.
+     */
+    locale: string;
 }
 
 export declare type ILivePreviewMode = "editor" | "preview";
 
+//? We kept it as number so that we could disable only the unrequired features,
+//? since the "Editor" mode will contain all the features of the "Preview" mode.
 export declare const enum ILivePreviewModeConfig {
     PREVIEW = 1,
     EDITOR = 2,

--- a/src/utils/__test__/handleUserConfig.test.ts
+++ b/src/utils/__test__/handleUserConfig.test.ts
@@ -414,6 +414,27 @@ describe("handleInitData()", () => {
             handleInitData(initData, config);
             expect(config.stackDetails.branch).toBe("main");
         });
+
+        test("should set locale from user config", () => {
+            const initData: Partial<IInitData> = {
+                enable: true,
+                stackDetails: {
+                    locale: "userlocale",
+                },
+            };
+
+            handleInitData(initData, config);
+            expect(config.stackDetails.locale).toBe("userlocale");
+        });
+
+        test("should set default locale if it is not passed", () => {
+            const initData: Partial<IInitData> = {
+                enable: true,
+            };
+
+            handleInitData(initData, config);
+            expect(config.stackDetails.locale).toBe("en-us");
+        });
     });
 });
 

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -53,6 +53,7 @@ export function getDefaultConfig(): IConfig {
             environment: "",
             contentTypeUid: "",
             entryUid: "",
+            locale: "en-us",
             branch: "main",
         },
 

--- a/src/utils/handleUserConfig.ts
+++ b/src/utils/handleUserConfig.ts
@@ -220,6 +220,9 @@ function handleStackDetails(
         stackSdk.headers?.branch ??
         config.stackDetails.branch;
 
+    config.stackDetails.locale =
+        initData.stackDetails?.locale ?? config.stackDetails.locale;
+
     if (config.mode >= ILivePreviewModeConfig.EDITOR) {
         if (!config.stackDetails.environment) {
             throw Error("Live preview SDK: environment is required");


### PR DESCRIPTION
The locale is required to determine which page should the visual editor open. This information is passed via the search params.

fixes: https://contentstack.atlassian.net/browse/VC-241