### PR TITLE
fix: redirect page to /live-editor

### DIFF
--- a/src/liveEditor/__test__/index.test.ts
+++ b/src/liveEditor/__test__/index.test.ts
@@ -207,7 +207,7 @@ describe("start editing button", () => {
 
         expect(mockReplace).toHaveBeenCalled();
         expect(mockReplace.mock.calls.at(0).at(0).toString()).toBe(
-            "https://app.contentstack.com/?branch=main&locale=en-us#!/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com"
+            "https://app.contentstack.com/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com?branch=main&locale=en-us"
         );
 
         const h1 = document.createElement("h1");
@@ -221,7 +221,7 @@ describe("start editing button", () => {
         startEditingButton.click();
 
         expect(mockReplace.mock.calls.at(1).at(0).toString()).toBe(
-            "https://app.contentstack.com/?branch=main&locale=en-uk#!/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com"
+            "https://app.contentstack.com/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com?branch=main&locale=en-uk"
         );
     });
 });

--- a/src/liveEditor/index.ts
+++ b/src/liveEditor/index.ts
@@ -75,7 +75,7 @@ export class VisualEditor {
         ) as string;
 
         const completeURL = new URL(
-            `/#!/live-editor/stack/${stack}/environment/${environment}/target_url/${encodeURIComponent(
+            `/live-editor/stack/${stack}/environment/${environment}/target_url/${encodeURIComponent(
                 window.location.href
             )}`,
             app_url


### PR DESCRIPTION
The page is used to redirect to `/#!/live-editor`. But, it must redirect to `/live-editor`.

fixes: https://contentstack.atlassian.net/browse/EB-397