### PR TITLE
feat: convert button to anchor tag

### DIFF
--- a/src/liveEditor/__test__/__snapshots__/index.test.ts.snap
+++ b/src/liveEditor/__test__/__snapshots__/index.test.ts.snap
@@ -57,7 +57,7 @@ exports[`Visual editor inline editing should add overlay to DOM when clicked 1`]
       
     
     </div>
-    <button
+    <a
       class="visual-editor__start-editing-btn"
       data-cslp-app-host="https://app.contentstack.com:443"
       data-cslp-branch="main"
@@ -65,6 +65,7 @@ exports[`Visual editor inline editing should add overlay to DOM when clicked 1`]
       data-cslp-locale="en-us"
       data-cslp-stack=""
       data-testid="vcms-start-editing-btn"
+      href="https://app.contentstack.com/live-editor"
     >
       <svg
         fill="none"
@@ -98,7 +99,7 @@ exports[`Visual editor inline editing should add overlay to DOM when clicked 1`]
       <span>
         Start Editing
       </span>
-    </button>
+    </a>
   </div>
 </body>
 `;
@@ -176,7 +177,7 @@ exports[`Visual editor on click, the sdk should do nothing if data-cslp not avai
       
     
     </div>
-    <button
+    <a
       class="visual-editor__start-editing-btn"
       data-cslp-app-host="https://app.contentstack.com:443"
       data-cslp-branch="main"
@@ -184,6 +185,7 @@ exports[`Visual editor on click, the sdk should do nothing if data-cslp not avai
       data-cslp-locale="en-us"
       data-cslp-stack=""
       data-testid="vcms-start-editing-btn"
+      href="https://app.contentstack.com/live-editor"
     >
       <svg
         fill="none"
@@ -217,7 +219,7 @@ exports[`Visual editor on click, the sdk should do nothing if data-cslp not avai
       <span>
         Start Editing
       </span>
-    </button>
+    </a>
   </div>
 </body>
 `;
@@ -268,7 +270,7 @@ exports[`Visual editor should append a visual editor container to the DOM 1`] = 
     
     
   </div>
-  <button
+  <a
     class="visual-editor__start-editing-btn"
     data-cslp-app-host="https://app.contentstack.com:443"
     data-cslp-branch="main"
@@ -276,6 +278,7 @@ exports[`Visual editor should append a visual editor container to the DOM 1`] = 
     data-cslp-locale="en-us"
     data-cslp-stack=""
     data-testid="vcms-start-editing-btn"
+    href="https://app.contentstack.com/live-editor"
   >
     <svg
       fill="none"
@@ -309,7 +312,7 @@ exports[`Visual editor should append a visual editor container to the DOM 1`] = 
     <span>
       Start Editing
     </span>
-  </button>
+  </a>
 </div>
 `;
 

--- a/src/liveEditor/__test__/index.test.ts
+++ b/src/liveEditor/__test__/index.test.ts
@@ -190,10 +190,8 @@ describe("start editing button", () => {
         config.stackDetails.apiKey = "api_key";
         config.stackDetails.environment = "environment";
 
-        const mockReplace = jest.fn();
         Object.defineProperty(window, "location", {
             value: {
-                assign: mockReplace,
                 href: "https://example.com",
             },
         });
@@ -205,8 +203,7 @@ describe("start editing button", () => {
 
         startEditingButton.click();
 
-        expect(mockReplace).toHaveBeenCalled();
-        expect(mockReplace.mock.calls.at(0).at(0).toString()).toBe(
+        expect(startEditingButton.getAttribute("href")).toBe(
             "https://app.contentstack.com/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com?branch=main&locale=en-us"
         );
 
@@ -220,7 +217,7 @@ describe("start editing button", () => {
 
         startEditingButton.click();
 
-        expect(mockReplace.mock.calls.at(1).at(0).toString()).toBe(
+        expect(startEditingButton.getAttribute("href")).toBe(
             "https://app.contentstack.com/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com?branch=main&locale=en-uk"
         );
     });

--- a/src/liveEditor/index.ts
+++ b/src/liveEditor/index.ts
@@ -101,7 +101,7 @@ export class VisualEditor {
             completeURL.searchParams.set("locale", locale);
         }
 
-        window.location.assign(completeURL.toString());
+        startEditingButton.setAttribute("href", completeURL.toString());
     };
 
     private handleMouseDownForVisualEditing = (event: MouseEvent): void => {

--- a/src/liveEditor/utils/__test__/generateStartEditingButton.test.ts
+++ b/src/liveEditor/utils/__test__/generateStartEditingButton.test.ts
@@ -21,13 +21,13 @@ describe("generateStartEditingButton", () => {
         jest.clearAllMocks();
     });
 
-    test("should  return a button", () => {
+    test("should  return an anchor tag", () => {
         const button = generateStartEditingButton(
             config,
             visualEditorWrapper,
             onClickEvent
         );
-        expect(button).toBeInstanceOf(HTMLButtonElement);
+        expect(button).toBeInstanceOf(HTMLAnchorElement);
     });
     test("should append the button within visualEditorWrapper", () => {
         expect(visualEditorWrapper.children.length).toBe(0);

--- a/src/liveEditor/utils/generateStartEditingButton.ts
+++ b/src/liveEditor/utils/generateStartEditingButton.ts
@@ -12,7 +12,7 @@ export function generateStartEditingButton(
     config: IConfig,
     visualEditorWrapper: HTMLDivElement | null,
     onClick: (event: MouseEvent) => void
-): HTMLButtonElement | undefined {
+): HTMLAnchorElement | undefined {
     const { apiKey, branch, environment, locale } = config.stackDetails;
     const { url } = config.clientUrlParams;
 
@@ -21,7 +21,7 @@ export function generateStartEditingButton(
         return;
     }
 
-    const startEditingButton = document.createElement("button");
+    const startEditingButton = document.createElement("a");
 
     startEditingButton.innerHTML = editIcon + `<span>Start Editing</span>`;
     startEditingButton.setAttribute("data-cslp-stack", apiKey);
@@ -29,6 +29,10 @@ export function generateStartEditingButton(
     startEditingButton.setAttribute("data-cslp-branch", branch);
     startEditingButton.setAttribute("data-cslp-app-host", url);
     startEditingButton.setAttribute("data-cslp-locale", locale);
+    startEditingButton.setAttribute(
+        "href",
+        "https://app.contentstack.com/live-editor"
+    );
     startEditingButton.setAttribute("data-testid", "vcms-start-editing-btn");
     startEditingButton.classList.add("visual-editor__start-editing-btn");
     startEditingButton.addEventListener("click", onClick);

--- a/src/styles.css
+++ b/src/styles.css
@@ -162,6 +162,7 @@ div.multiple div.cslp-tooltip-child:hover:before {
     z-index: 200;
 }
 .visual-editor__start-editing-btn {
+    text-decoration: none;
     position: fixed;
     bottom: 30px;
     left: 50%;


### PR DESCRIPTION
Converting the Start editing button will allow it to open the URL in the new tab.

fixes: https://contentstack.atlassian.net/browse/EB-398