### PR TITLE
feat: hide start editing button inside editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1853,7 +1853,7 @@
         },
         "node_modules/@contentstack/advanced-post-message": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/contentstack/adv-post-message.git#3cea7733bbccc5636263378edd2277b3051c1f0b",
+            "resolved": "git+ssh://git@github.com/contentstack/adv-post-message.git#20161221e43c696c40a0e1421c44269cd9b08b09",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -14040,7 +14040,7 @@
             "dev": true
         },
         "@contentstack/advanced-post-message": {
-            "version": "git+ssh://git@github.com/contentstack/adv-post-message.git#3cea7733bbccc5636263378edd2277b3051c1f0b",
+            "version": "git+ssh://git@github.com/contentstack/adv-post-message.git#20161221e43c696c40a0e1421c44269cd9b08b09",
             "dev": true,
             "from": "@contentstack/advanced-post-message@github:contentstack/adv-post-message#VC-216-implement-adv-post-robot",
             "requires": {

--- a/src/liveEditor/__test__/__snapshots__/index.test.ts.snap
+++ b/src/liveEditor/__test__/__snapshots__/index.test.ts.snap
@@ -57,49 +57,6 @@ exports[`Visual editor inline editing should add overlay to DOM when clicked 1`]
       
     
     </div>
-    <a
-      class="visual-editor__start-editing-btn"
-      data-cslp-app-host="https://app.contentstack.com:443"
-      data-cslp-branch="main"
-      data-cslp-environment=""
-      data-cslp-locale="en-us"
-      data-cslp-stack=""
-      data-testid="vcms-start-editing-btn"
-      href="https://app.contentstack.com/live-editor"
-    >
-      <svg
-        fill="none"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        
-
-        <g
-          id="Edit"
-        >
-          
-
-          <path
-            clip-rule="evenodd"
-            d="M3.58347 15.3803C3.35617 15.6076 3.22019 15.9104 3.20131 16.2313L3.00244 19.6122C2.95629 20.3967 3.60524 21.0456 4.38975 20.9995L7.7706 20.8006C8.0915 20.7817 8.39431 20.6458 8.62161 20.4185L20.6176 8.4225C21.1301 7.90993 21.1301 7.07891 20.6176 6.56634L17.4356 3.38436C16.923 2.8718 16.092 2.8718 15.5794 3.38436L3.58347 15.3803ZM4.32437 16.2974C4.32707 16.2515 4.3465 16.2083 4.37897 16.1758L14.2003 6.35446L17.4954 9.64949C17.5492 9.70337 17.6113 9.74403 17.6776 9.77148L7.82611 19.623C7.79364 19.6554 7.75038 19.6749 7.70454 19.6776L4.32369 19.8764C4.21161 19.883 4.11891 19.7903 4.1255 19.6782L4.32437 16.2974ZM18.4128 9.03624L19.8221 7.627C19.8953 7.55378 19.8953 7.43506 19.8221 7.36184L16.6401 4.17986C16.5669 4.10663 16.4481 4.10663 16.3749 4.17986L14.9958 5.55897L18.2908 8.854C18.3447 8.90788 18.3854 8.96996 18.4128 9.03624Z"
-            fill="white"
-            fill-rule="evenodd"
-            id="Edit_2"
-          />
-          
-
-        </g>
-        
-
-      </svg>
-      
-
-      <span>
-        Start Editing
-      </span>
-    </a>
   </div>
 </body>
 `;
@@ -177,49 +134,6 @@ exports[`Visual editor on click, the sdk should do nothing if data-cslp not avai
       
     
     </div>
-    <a
-      class="visual-editor__start-editing-btn"
-      data-cslp-app-host="https://app.contentstack.com:443"
-      data-cslp-branch="main"
-      data-cslp-environment=""
-      data-cslp-locale="en-us"
-      data-cslp-stack=""
-      data-testid="vcms-start-editing-btn"
-      href="https://app.contentstack.com/live-editor"
-    >
-      <svg
-        fill="none"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        
-
-        <g
-          id="Edit"
-        >
-          
-
-          <path
-            clip-rule="evenodd"
-            d="M3.58347 15.3803C3.35617 15.6076 3.22019 15.9104 3.20131 16.2313L3.00244 19.6122C2.95629 20.3967 3.60524 21.0456 4.38975 20.9995L7.7706 20.8006C8.0915 20.7817 8.39431 20.6458 8.62161 20.4185L20.6176 8.4225C21.1301 7.90993 21.1301 7.07891 20.6176 6.56634L17.4356 3.38436C16.923 2.8718 16.092 2.8718 15.5794 3.38436L3.58347 15.3803ZM4.32437 16.2974C4.32707 16.2515 4.3465 16.2083 4.37897 16.1758L14.2003 6.35446L17.4954 9.64949C17.5492 9.70337 17.6113 9.74403 17.6776 9.77148L7.82611 19.623C7.79364 19.6554 7.75038 19.6749 7.70454 19.6776L4.32369 19.8764C4.21161 19.883 4.11891 19.7903 4.1255 19.6782L4.32437 16.2974ZM18.4128 9.03624L19.8221 7.627C19.8953 7.55378 19.8953 7.43506 19.8221 7.36184L16.6401 4.17986C16.5669 4.10663 16.4481 4.10663 16.3749 4.17986L14.9958 5.55897L18.2908 8.854C18.3447 8.90788 18.3854 8.96996 18.4128 9.03624Z"
-            fill="white"
-            fill-rule="evenodd"
-            id="Edit_2"
-          />
-          
-
-        </g>
-        
-
-      </svg>
-      
-
-      <span>
-        Start Editing
-      </span>
-    </a>
   </div>
 </body>
 `;
@@ -270,49 +184,6 @@ exports[`Visual editor should append a visual editor container to the DOM 1`] = 
     
     
   </div>
-  <a
-    class="visual-editor__start-editing-btn"
-    data-cslp-app-host="https://app.contentstack.com:443"
-    data-cslp-branch="main"
-    data-cslp-environment=""
-    data-cslp-locale="en-us"
-    data-cslp-stack=""
-    data-testid="vcms-start-editing-btn"
-    href="https://app.contentstack.com/live-editor"
-  >
-    <svg
-      fill="none"
-      height="24"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      
-
-      <g
-        id="Edit"
-      >
-        
-
-        <path
-          clip-rule="evenodd"
-          d="M3.58347 15.3803C3.35617 15.6076 3.22019 15.9104 3.20131 16.2313L3.00244 19.6122C2.95629 20.3967 3.60524 21.0456 4.38975 20.9995L7.7706 20.8006C8.0915 20.7817 8.39431 20.6458 8.62161 20.4185L20.6176 8.4225C21.1301 7.90993 21.1301 7.07891 20.6176 6.56634L17.4356 3.38436C16.923 2.8718 16.092 2.8718 15.5794 3.38436L3.58347 15.3803ZM4.32437 16.2974C4.32707 16.2515 4.3465 16.2083 4.37897 16.1758L14.2003 6.35446L17.4954 9.64949C17.5492 9.70337 17.6113 9.74403 17.6776 9.77148L7.82611 19.623C7.79364 19.6554 7.75038 19.6749 7.70454 19.6776L4.32369 19.8764C4.21161 19.883 4.11891 19.7903 4.1255 19.6782L4.32437 16.2974ZM18.4128 9.03624L19.8221 7.627C19.8953 7.55378 19.8953 7.43506 19.8221 7.36184L16.6401 4.17986C16.5669 4.10663 16.4481 4.10663 16.3749 4.17986L14.9958 5.55897L18.2908 8.854C18.3447 8.90788 18.3854 8.96996 18.4128 9.03624Z"
-          fill="white"
-          fill-rule="evenodd"
-          id="Edit_2"
-        />
-        
-
-      </g>
-      
-
-    </svg>
-    
-
-    <span>
-      Start Editing
-    </span>
-  </a>
 </div>
 `;
 

--- a/src/liveEditor/__test__/index.test.ts
+++ b/src/liveEditor/__test__/index.test.ts
@@ -49,7 +49,9 @@ describe("Visual editor", () => {
 
         new VisualEditor(config);
 
-        visualEditorDOM = document.querySelector(".visual-editor__container");
+        visualEditorDOM = document.querySelector(
+            `[data-testid="visual-editor__container"]`
+        );
 
         expect(visualEditorDOM).toMatchSnapshot();
     });
@@ -164,62 +166,6 @@ describe("Visual editor", () => {
                 expect(replaceBtn).toBeUndefined();
             });
         });
-    });
-});
-
-describe("start editing button", () => {
-    let config: IConfig;
-    beforeEach(() => {
-        config = getDefaultConfig();
-    });
-    afterEach(() => {
-        document.getElementsByTagName("html")[0].innerHTML = "";
-        jest.restoreAllMocks();
-    });
-
-    test("should exist", () => {
-        new VisualEditor(config);
-        const startEditingButton = document.querySelector(
-            `[data-testid="vcms-start-editing-btn"]`
-        );
-
-        expect(startEditingButton).toBeDefined();
-    });
-
-    test("should go to an URL upon click", () => {
-        config.stackDetails.apiKey = "api_key";
-        config.stackDetails.environment = "environment";
-
-        Object.defineProperty(window, "location", {
-            value: {
-                href: "https://example.com",
-            },
-        });
-
-        new VisualEditor(config);
-        const startEditingButton = document.querySelector(
-            `[data-testid="vcms-start-editing-btn"]`
-        ) as HTMLButtonElement;
-
-        startEditingButton.click();
-
-        expect(startEditingButton.getAttribute("href")).toBe(
-            "https://app.contentstack.com/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com?branch=main&locale=en-us"
-        );
-
-        const h1 = document.createElement("h1");
-        h1.setAttribute(
-            "data-cslp",
-            "all_fields.blt58a50b4cebae75c5.en-uk.title"
-        );
-
-        document.body.appendChild(h1);
-
-        startEditingButton.click();
-
-        expect(startEditingButton.getAttribute("href")).toBe(
-            "https://app.contentstack.com/live-editor/stack/api_key/environment/environment/target_url/https%3A%2F%2Fexample.com?branch=main&locale=en-uk"
-        );
     });
 });
 

--- a/src/liveEditor/__test__/withoutIframe.test.ts
+++ b/src/liveEditor/__test__/withoutIframe.test.ts
@@ -26,9 +26,12 @@ describe("When outside the Visual editor, the Visual Editor", () => {
     afterAll(() => {
         mockedConsoleError.mockRestore();
     });
-    test("should have the start editing button", () => {
+    test("should have the start editing button", async () => {
         const config: IConfig = getDefaultConfig();
         new VisualEditor(config);
+
+        await sleep();
+
         const startEditingButton = document.querySelector(
             `[data-testid="vcms-start-editing-btn"]`
         );

--- a/src/liveEditor/index.ts
+++ b/src/liveEditor/index.ts
@@ -40,7 +40,8 @@ export class VisualEditor {
         this.handleMouseDownForVisualEditing =
             this.handleMouseDownForVisualEditing.bind(this);
 
-        // list all the keys of the liveEditorPostMessage object
+        this.appendVisualEditorDOM();
+
         liveEditorPostMessage
             ?.send<{ contentTypes: Record<string, IPageSchema> }>("init")
             .then((data) => {
@@ -56,8 +57,14 @@ export class VisualEditor {
                     this.handleMouseDownForVisualEditing
                 );
                 window.addEventListener("mousemove", this.handleMouseHover);
+            })
+            .catch(() => {
+                generateStartEditingButton(
+                    config,
+                    this.visualEditorWrapper,
+                    this.handleStartEditing
+                );
             });
-        this.appendVisualEditorDOM(config);
     }
 
     private handleStartEditing = (event: MouseEvent): void => {
@@ -194,7 +201,7 @@ export class VisualEditor {
         this.previousHoveredTargetDOM = editableElement;
     }, 10);
 
-    appendVisualEditorDOM = (config: IConfig): void => {
+    appendVisualEditorDOM = (): void => {
         const visualEditorDOM = document.querySelector(
             ".visual-editor__container"
         );
@@ -213,12 +220,6 @@ export class VisualEditor {
                 overlay: this.overlayWrapper,
             });
         }
-
-        generateStartEditingButton(
-            config,
-            this.visualEditorWrapper,
-            this.handleStartEditing
-        );
     };
     hideCustomCursor = (): void => {
         if (this.customCursor) {


### PR DESCRIPTION
The start editing button should be shown only when we are outside the editor. It must be hidden when we are inside the editor.

fixes: https://contentstack.atlassian.net/browse/EB-404