### PR TITLE
feat: escape key closes the overlay

### DIFF
--- a/src/liveEditor/index.ts
+++ b/src/liveEditor/index.ts
@@ -207,12 +207,14 @@ export class VisualEditor {
         );
         if (!visualEditorDOM) {
             this.customCursor = generateVisualEditorCursor();
-            this.overlayWrapper = generateVisualEditorOverlay((event) =>
-                hideFocusOverlay(event, {
-                    previousSelectedEditableDOM:
-                        this.previousSelectedEditableDOM,
-                    visualEditorWrapper: this.visualEditorWrapper,
-                })
+            this.overlayWrapper = generateVisualEditorOverlay(
+                (visualEditorOverlayWrapper = null) =>
+                    hideFocusOverlay({
+                        previousSelectedEditableDOM:
+                            this.previousSelectedEditableDOM,
+                        visualEditorWrapper: this.visualEditorWrapper,
+                        visualEditorOverlayWrapper,
+                    })
             );
 
             this.visualEditorWrapper = generateVisualEditorWrapper({

--- a/src/liveEditor/utils/__test__/focusOverlayWrapper.test.ts
+++ b/src/liveEditor/utils/__test__/focusOverlayWrapper.test.ts
@@ -112,11 +112,11 @@ describe("addFocusOverlay", () => {
 
     test("should run onClickCallback when the focus overlay is clicked", () => {
         addFocusOverlay(targetElement, focusOverlayWrapper);
-        const visualEditorOverlayWrapper = document.querySelector(
-            `[data-testid="visual-editor__overlay__wrapper"]`
+        const visualEditorOverlay = document.querySelector(
+            `[data-testid="visual-editor__overlay--top"]`
         ) as HTMLDivElement;
 
-        visualEditorOverlayWrapper?.dispatchEvent(
+        visualEditorOverlay?.dispatchEvent(
             new MouseEvent("click", {
                 bubbles: true,
                 cancelable: true,
@@ -128,7 +128,6 @@ describe("addFocusOverlay", () => {
 });
 
 describe("hideFocusOverlay", () => {
-    let mockEvent: MouseEvent;
     let editedElement: HTMLParagraphElement;
     let focusOverlayWrapper: HTMLDivElement;
     let singleFocusOverlay: HTMLDivElement;
@@ -148,12 +147,15 @@ describe("hideFocusOverlay", () => {
             bottom: 20,
         })) as any;
 
-        focusOverlayWrapper = generateVisualEditorOverlay((event) => {
-            hideFocusOverlay(event, {
-                previousSelectedEditableDOM: editedElement,
-                visualEditorWrapper,
-            });
-        });
+        focusOverlayWrapper = generateVisualEditorOverlay(
+            (visualEditorOverlayWrapper) => {
+                hideFocusOverlay({
+                    previousSelectedEditableDOM: editedElement,
+                    visualEditorWrapper,
+                    visualEditorOverlayWrapper,
+                });
+            }
+        );
         document.body.appendChild(visualEditorWrapper);
         document.body.appendChild(editedElement);
         document.body.appendChild(focusOverlayWrapper);
@@ -173,15 +175,10 @@ describe("hideFocusOverlay", () => {
     test("should not hide the overlay if the focus overlay wrapper is null", () => {
         expect(focusOverlayWrapper.classList.contains("visible")).toBe(true);
 
-        // We didn't dispatch it to simulate the case where the targetElement is not present
-        mockEvent = new MouseEvent("click", {
-            bubbles: true,
-            cancelable: true,
-        });
-
-        hideFocusOverlay(mockEvent, {
+        hideFocusOverlay({
             previousSelectedEditableDOM: editedElement,
             visualEditorWrapper,
+            visualEditorOverlayWrapper: null,
         });
 
         expect(focusOverlayWrapper.classList.contains("visible")).toBe(true);
@@ -246,12 +243,15 @@ describe("hideFocusOverlay", () => {
             bottom: 20,
         })) as any;
 
-        const focusOverlayWrapper = generateVisualEditorOverlay((event) => {
-            hideFocusOverlay(event, {
-                previousSelectedEditableDOM: editedElement,
-                visualEditorWrapper,
-            });
-        });
+        const focusOverlayWrapper = generateVisualEditorOverlay(
+            (visualEditorOverlayWrapper = null) => {
+                hideFocusOverlay({
+                    previousSelectedEditableDOM: editedElement,
+                    visualEditorWrapper,
+                    visualEditorOverlayWrapper,
+                });
+            }
+        );
         document.body.appendChild(visualEditorWrapper);
         document.body.appendChild(editedElement);
         document.body.appendChild(focusOverlayWrapper);
@@ -267,5 +267,16 @@ describe("hideFocusOverlay", () => {
         singleFocusOverlay.click();
 
         expect(cleanIndividualFieldResidual).toHaveBeenCalledTimes(1);
+    });
+
+    test("should hide the overlay if the escape key is pressed", () => {
+        expect(focusOverlayWrapper.classList.contains("visible")).toBe(true);
+
+        const escapeEvent = new KeyboardEvent("keydown", {
+            key: "Escape",
+        });
+        window.dispatchEvent(escapeEvent);
+
+        expect(focusOverlayWrapper.classList.contains("visible")).toBe(false);
     });
 });

--- a/src/liveEditor/utils/__test__/generateVisualEditorDom.test.ts
+++ b/src/liveEditor/utils/__test__/generateVisualEditorDom.test.ts
@@ -17,7 +17,9 @@ describe("generateVisualEditorOverlay", () => {
     });
 
     test("should run the function when clicked on the overlay", () => {
-        const overlay = generateVisualEditorOverlay(onOverlayClick);
+        const overlayWrapper = generateVisualEditorOverlay(onOverlayClick);
+        const overlay = overlayWrapper.children[0] as HTMLDivElement;
+
         overlay.click();
         expect(onOverlayClick).toHaveBeenCalledTimes(1);
     });

--- a/src/liveEditor/utils/focusOverlayWrapper.ts
+++ b/src/liveEditor/utils/focusOverlayWrapper.ts
@@ -85,22 +85,19 @@ export function addFocusOverlay(
  * @param event - The mouse event that triggered the function.
  * @param elements - An object containing references to the focus overlay wrapper, the previously selected editable DOM element, and the visual editor wrapper.
  */
-export function hideFocusOverlay(
-    event: MouseEvent,
-    elements: {
-        previousSelectedEditableDOM: Element | null;
-        visualEditorWrapper: HTMLDivElement | null;
-    }
-): void {
-    const targetElement = event.target as Element;
-    const { previousSelectedEditableDOM, visualEditorWrapper } = elements;
+export function hideFocusOverlay(elements: {
+    previousSelectedEditableDOM: Element | null;
+    visualEditorWrapper: HTMLDivElement | null;
+    visualEditorOverlayWrapper: HTMLDivElement | null;
+}): void {
+    const {
+        previousSelectedEditableDOM,
+        visualEditorWrapper,
+        visualEditorOverlayWrapper,
+    } = elements;
 
-    if (targetElement?.classList.contains("visual-editor__overlay")) {
-        const focusOverlayWrapper = targetElement.closest(
-            ".visual-editor__overlay__wrapper"
-        ) as HTMLDivElement;
-
-        focusOverlayWrapper.classList.remove("visible");
+    if (visualEditorOverlayWrapper) {
+        visualEditorOverlayWrapper.classList.remove("visible");
 
         if (previousSelectedEditableDOM) {
             if (previousSelectedEditableDOM.hasAttribute("contenteditable")) {
@@ -118,7 +115,7 @@ export function hideFocusOverlay(
             }
 
             cleanIndividualFieldResidual({
-                overlayWrapper: focusOverlayWrapper,
+                overlayWrapper: visualEditorOverlayWrapper,
                 previousSelectedEditableDOM: previousSelectedEditableDOM,
                 visualEditorWrapper: visualEditorWrapper,
             });

--- a/src/liveEditor/utils/generateVisualEditorDom.ts
+++ b/src/liveEditor/utils/generateVisualEditorDom.ts
@@ -25,7 +25,7 @@ export function generateVisualEditorCursor(): HTMLDivElement {
 }
 
 export function generateVisualEditorOverlay(
-    onClick: (event: MouseEvent) => void
+    onClick: (visualEditorOverlayWrapper: HTMLDivElement | null) => void
 ): HTMLDivElement {
     const visualEditorOverlayWrapper = document.createElement("div");
 
@@ -43,7 +43,19 @@ export function generateVisualEditorOverlay(
         <div data-testid="visual-editor__overlay--outline" class="visual-editor__overlay--outline"></div>
     `;
 
-    visualEditorOverlayWrapper.addEventListener("click", onClick);
+    visualEditorOverlayWrapper.addEventListener("click", (event) => {
+        const targetElement = event.target as Element;
+
+        if (targetElement.classList.contains("visual-editor__overlay")) {
+            onClick(visualEditorOverlayWrapper);
+        }
+    });
+
+    window.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+            onClick(visualEditorOverlayWrapper);
+        }
+    });
 
     return visualEditorOverlayWrapper;
 }


### PR DESCRIPTION
I have separated the logic for click and hide overlay. Now, the same logic is used for escape key and overlay click. Also, fixed some test cases to click the appropiate overlay.

fixes: https://contentstack.atlassian.net/browse/EB-562