### PR TITLE
fix: update field adds `<div/>` element

### DIFF
--- a/src/liveEditor/utils/focusOverlayWrapper.ts
+++ b/src/liveEditor/utils/focusOverlayWrapper.ts
@@ -109,7 +109,10 @@ export function hideFocusOverlay(elements: {
                 liveEditorPostMessage?.send(
                     LiveEditorPostMessageEvents.UPDATE_FIELD,
                     {
-                        data: previousSelectedEditableDOM.innerHTML,
+                        data:
+                            "innerText" in previousSelectedEditableDOM
+                                ? previousSelectedEditableDOM.innerText
+                                : previousSelectedEditableDOM.textContent,
                         fieldMetadata: extractDetailsFromCslp(
                             previousSelectedEditableDOM.getAttribute(
                                 "data-cslp"


### PR DESCRIPTION
We were adding inner HTML that adds the inline div elements. We replaced it with innerText if available as it retains the `\n`. However, if it is not available we fallback to text content.

fixes: https://contentstack.atlassian.net/browse/EB-817