### PR TITLE
feat: set live preview details from the URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
-                "@types/jsdom": "^21.1.6",
                 "just-camel-case": "^4.0.2",
                 "lodash": "^4.17.21",
                 "morphdom": "^2.6.1",
@@ -22,6 +21,7 @@
                 "@contentstack/advanced-post-message": "github:contentstack/adv-post-message#EB-676-config-support",
                 "@testing-library/jest-dom": "^5.14.1",
                 "@types/jest": "^27.0.1",
+                "@types/jsdom": "^21.1.6",
                 "@types/lodash": "^4.14.195",
                 "@types/mustache": "^4.2.2",
                 "@types/uuid": "^8.3.1",
@@ -3026,6 +3026,7 @@
             "version": "21.1.6",
             "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
             "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
+            "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/tough-cookie": "*",
@@ -3059,7 +3060,8 @@
         "node_modules/@types/node": {
             "version": "16.9.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
-            "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w=="
+            "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
+            "dev": true
         },
         "node_modules/@types/prettier": {
             "version": "2.7.2",
@@ -3131,7 +3133,8 @@
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+            "dev": true
         },
         "node_modules/@types/uuid": {
             "version": "8.3.1",
@@ -5214,6 +5217,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12"
             },
@@ -9804,6 +9808,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+            "dev": true,
             "dependencies": {
                 "entities": "^4.4.0"
             },
@@ -15332,6 +15337,7 @@
             "version": "21.1.6",
             "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
             "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
+            "dev": true,
             "requires": {
                 "@types/node": "*",
                 "@types/tough-cookie": "*",
@@ -15365,7 +15371,8 @@
         "@types/node": {
             "version": "16.9.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
-            "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w=="
+            "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
+            "dev": true
         },
         "@types/prettier": {
             "version": "2.7.2",
@@ -15437,7 +15444,8 @@
         "@types/tough-cookie": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+            "dev": true
         },
         "@types/uuid": {
             "version": "8.3.1",
@@ -17014,7 +17022,8 @@
         "entities": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true
         },
         "envinfo": {
             "version": "7.8.1",
@@ -20429,6 +20438,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
             "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+            "dev": true,
             "requires": {
                 "entities": "^4.4.0"
             }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@contentstack/advanced-post-message": "github:contentstack/adv-post-message#EB-676-config-support",
         "@testing-library/jest-dom": "^5.14.1",
         "@types/jest": "^27.0.1",
+        "@types/jsdom": "^21.1.6",
         "@types/lodash": "^4.14.195",
         "@types/mustache": "^4.2.2",
         "@types/uuid": "^8.3.1",
@@ -63,7 +64,6 @@
         "url": "https://github.com/contentstack/live-preview-sdk.git"
     },
     "dependencies": {
-        "@types/jsdom": "^21.1.6",
         "just-camel-case": "^4.0.2",
         "lodash": "^4.17.21",
         "morphdom": "^2.6.1",

--- a/src/__test__/contentstack-live-preview-HOC.test.ts
+++ b/src/__test__/contentstack-live-preview-HOC.test.ts
@@ -349,15 +349,6 @@ describe("setConfigFromParams()", () => {
         expect(ContentstackLivePreview.hash).toBe(livePreviewHash);
     });
 
-    test("should throw an error if param is not an object", () => {
-        ContentstackLivePreview.init();
-
-        expect(() => {
-            // @ts-ignore
-            ContentstackLivePreview.setConfigFromParams("");
-        }).toThrowError("Live preview SDK: query param must be an object");
-    });
-
     test("should set the params if it was set before initialization", () => {
         const livePreviewHash = "livePreviewHash1234";
 

--- a/src/__test__/live-preview.test.ts
+++ b/src/__test__/live-preview.test.ts
@@ -919,3 +919,45 @@ describe("live preview hash", () => {
         expect(livePreview.hash).toBe(livePreviewHash);
     });
 });
+
+describe("Live preview config update", () => {
+    beforeEach(() => {
+        Config.reset();
+    });
+
+    afterAll(() => {
+        Config.reset();
+    });
+
+    test("should update the config from the URL", () => {
+        const searchParams = new URLSearchParams(window.location.search);
+        searchParams.set("content_type_uid", "test");
+        searchParams.set("entry_uid", "test");
+        searchParams.set("live_preview", "test");
+
+        // mock window location
+        Object.defineProperty(window, "location", {
+            writable: true,
+            value: {
+                search: searchParams.toString(),
+            },
+        });
+
+        expect(Config.get().stackDetails.contentTypeUid).toEqual("");
+        expect(Config.get().stackDetails.entryUid).toEqual("");
+        expect(Config.get().hash).toEqual("");
+
+        new LivePreview();
+
+        expect(Config.get().stackDetails.contentTypeUid).toEqual("test");
+        expect(Config.get().stackDetails.entryUid).toEqual("test");
+        expect(Config.get().hash).toEqual("test");
+
+        Object.defineProperty(window, "location", {
+            writable: true,
+            value: {
+                search: "",
+            },
+        });
+    });
+});

--- a/src/contentstack-live-preview-HOC.ts
+++ b/src/contentstack-live-preview-HOC.ts
@@ -12,6 +12,7 @@ import {
 import LivePreview from "./live-preview";
 import { getUserInitData } from "./utils/defaults";
 import { PublicLogger } from "./utils/public-logger";
+import { setConfigFromParams } from "./utils/configHandler";
 
 export class ContentstackLivePreview {
     static livePreview: LivePreview | null = null;
@@ -40,9 +41,7 @@ export class ContentstackLivePreview {
                     ContentstackLivePreview.publish
                 );
 
-                ContentstackLivePreview.livePreview.setConfigFromParams(
-                    this.configs.params
-                );
+                setConfigFromParams(this.configs.params);
                 this.configs.params = {};
 
                 return Promise.resolve(ContentstackLivePreview.livePreview);
@@ -69,6 +68,8 @@ export class ContentstackLivePreview {
      * Sets the live preview hash from the query param which is
      * accessible via `hash` property.
      * @param params query param in an object form
+     * @deprecated The SDK will automatically get the hash from the URL.
+     *
      */
     static setConfigFromParams(
         params: ConstructorParameters<typeof URLSearchParams>[0] = {}
@@ -78,7 +79,7 @@ export class ContentstackLivePreview {
             return;
         }
 
-        this.livePreview.setConfigFromParams(params);
+        setConfigFromParams(params);
     }
 
     private static publish(): void {
@@ -115,9 +116,7 @@ export class ContentstackLivePreview {
                 ContentstackLivePreview.publish
             );
 
-            ContentstackLivePreview.livePreview.setConfigFromParams(
-                this.configs.params
-            );
+            setConfigFromParams(this.configs.params);
 
             this.configs.params = {};
 

--- a/src/utils/__test__/confighandler.test.ts
+++ b/src/utils/__test__/confighandler.test.ts
@@ -1,4 +1,4 @@
-import Config from "../configHandler";
+import Config, { updateConfigFromUrl } from "../configHandler";
 import { getDefaultConfig } from "../defaults";
 
 describe("Config", () => {
@@ -81,5 +81,61 @@ describe("Config", () => {
                 apiKey: "api-key",
             },
         });
+    });
+});
+
+describe("update config from url", () => {
+    beforeEach(() => {
+        Config.reset();
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, "location", {
+            writable: true,
+            value: {
+                search: "",
+            },
+        });
+    });
+
+    afterAll(() => {
+        Config.reset();
+    });
+
+    it("should update config from url if available", () => {
+        const searchParams = new URLSearchParams(window.location.search);
+        searchParams.set("content_type_uid", "test");
+        searchParams.set("entry_uid", "test");
+        searchParams.set("live_preview", "test");
+
+        // mock window location
+        Object.defineProperty(window, "location", {
+            writable: true,
+            value: {
+                search: searchParams.toString(),
+            },
+        });
+
+        expect(Config.get().stackDetails.contentTypeUid).toEqual("");
+        expect(Config.get().stackDetails.entryUid).toEqual("");
+        expect(Config.get().hash).toEqual("");
+
+        updateConfigFromUrl();
+
+        expect(Config.get().stackDetails.contentTypeUid).toEqual("test");
+        expect(Config.get().stackDetails.entryUid).toEqual("test");
+        expect(Config.get().hash).toEqual("test");
+    });
+
+    it("should be default config if url params are not available", () => {
+        expect(Config.get().stackDetails.contentTypeUid).toEqual("");
+        expect(Config.get().stackDetails.entryUid).toEqual("");
+        expect(Config.get().hash).toEqual("");
+
+        updateConfigFromUrl();
+
+        expect(Config.get().stackDetails.contentTypeUid).toEqual("");
+        expect(Config.get().stackDetails.entryUid).toEqual("");
+        expect(Config.get().hash).toEqual("");
     });
 });

--- a/src/utils/configHandler.ts
+++ b/src/utils/configHandler.ts
@@ -28,3 +28,64 @@ class Config {
 }
 
 export default Config;
+
+/**
+ * Updates the configuration from the URL parameters.
+ * It will receive live_preview containing the hash, content_type_uid and entry_uid.
+ */
+
+export function updateConfigFromUrl(): void {
+    const searchParams = new URLSearchParams(window.location.search);
+    setConfigFromParams(searchParams.toString());
+}
+
+/**
+ * Sets the live preview hash, content_type_uid and entry_uid
+ * from the query param to config.
+ *
+ * @param params query param in an object form, query string.
+ *
+ * @example
+ * ```js
+ * setConfigFromParams({
+ *      live_preview: "hash",
+ *      content_type_uid: "content_type_uid",
+ *      entry_uid: "entry_uid",
+ * });
+ * ```
+ *
+ * @example
+ * ```js
+ * setConfigFromParams("?live_preview=hash&content_type_uid=content_type_uid&entry_uid=entry_uid");
+ * ```
+ * Basically anything that can be passed to `URLSearchParams` constructor.
+ */
+
+export function setConfigFromParams(
+    params: ConstructorParameters<typeof URLSearchParams>[0] = {}
+): void {
+    const urlParams = new URLSearchParams(params);
+    const live_preview = urlParams.get("live_preview");
+    const content_type_uid = urlParams.get("content_type_uid");
+    const entry_uid = urlParams.get("entry_uid");
+
+    const stackSdkLivePreview = Config.get().stackSdk.live_preview;
+
+    if (live_preview) {
+        Config.set("hash", live_preview);
+        stackSdkLivePreview.hash = live_preview;
+        stackSdkLivePreview.live_preview = live_preview;
+    }
+
+    if (content_type_uid) {
+        Config.set("stackDetails.contentTypeUid", content_type_uid);
+        stackSdkLivePreview.content_type_uid = content_type_uid;
+    }
+
+    if (entry_uid) {
+        Config.set("stackDetails.entryUid", entry_uid);
+        stackSdkLivePreview.entry_uid = entry_uid;
+    }
+
+    Config.set("stackSdk.live_preview", stackSdkLivePreview);
+}


### PR DESCRIPTION
The live preview editor will get the hash, content_type_uid, and entry_uid from the URL. So, we save them to the config and update the Stack SDK.

This will help us get the preview data from the first call and not wait for init.

fixes: https://contentstack.atlassian.net/browse/EB-890