### PR TITLE
feat: isSSR boolean value in liveEditorPostMessage.send event's payload

### DIFF
--- a/src/liveEditor/index.ts
+++ b/src/liveEditor/index.ts
@@ -105,7 +105,9 @@ export class VisualEditor {
         this.addFocusedToolbar = this.addFocusedToolbar.bind(this);
 
         liveEditorPostMessage
-            ?.send<{ windowType: ILivePreviewWindowType }>("init")
+            ?.send<{ windowType: ILivePreviewWindowType }>("init", {
+                isSSR: Config.get().ssr,
+            })
             .then((data) => {
                 const { windowType = ILivePreviewWindowType.EDITOR } = data;
                 Config.set("windowType", windowType);


### PR DESCRIPTION
Included the following `{ isSSR: Config.get().ssr }` in the payload of Live Editor's "init" post message which will be used to set the global state of page rendering mode `pageRenderMode` in Visual Editor.

  
  fixes: https://contentstack.atlassian.net/browse/EB-102