### PR TITLE
Introduced Instance's `fieldPathWithIndex` in post-message payloads

### DIFF
--- a/src/cslp/__test__/cslpdata.test.ts
+++ b/src/cslp/__test__/cslpdata.test.ts
@@ -20,6 +20,9 @@ describe("extractDetailsFromCslp", () => {
                 },
                 index: 0,
             },
+            instance: {
+                fieldPathWithIndex: "field1.field2.0.field3",
+            }
         };
         expect(extractDetailsFromCslp(cslpValue)).toEqual(expected);
     });
@@ -38,6 +41,9 @@ describe("extractDetailsFromCslp", () => {
                 parentDetails: null,
                 index: -1,
             },
+            instance: {
+                fieldPathWithIndex: "field1.field2.field3",
+            }
         };
         expect(extractDetailsFromCslp(cslpValue)).toEqual(expected);
     });
@@ -58,6 +64,9 @@ describe("extractDetailsFromCslp", () => {
                 },
                 index: 0,
             },
+            instance: {
+                fieldPathWithIndex: "field.0",
+            }
         };
         expect(extractDetailsFromCslp(cslpValue)).toEqual(expected);
     });
@@ -81,6 +90,9 @@ describe("extractDetailsFromCslp", () => {
                 },
                 index: 3,
             },
+            instance: {
+                fieldPathWithIndex: "field1.0.field3.field4.3",
+            }
         };
         expect(extractDetailsFromCslp(cslpValue)).toEqual(expected);
     });

--- a/src/cslp/cslpdata.ts
+++ b/src/cslp/cslpdata.ts
@@ -15,7 +15,7 @@ import { DeepSignal } from "deepsignal";
 export function extractDetailsFromCslp(cslpValue: string): CslpData {
     const [content_type_uid, entry_uid, locale, ...fieldPath] =
         cslpValue.split(".");
-
+    const instancePathWithInstance = fieldPath.join(".");
     const calculatedPath = fieldPath.filter((path) => {
         const isEmpty = isNil(path);
         const isNumber = isFinite(+path);
@@ -47,6 +47,9 @@ export function extractDetailsFromCslp(cslpValue: string): CslpData {
         fieldPath: calculatedPath.join("."),
         fieldPathWithIndex: fieldPath.join("."),
         multipleFieldMetadata: multipleFieldMetadata,
+        instance: {
+            fieldPathWithIndex: instancePathWithInstance
+        },
     };
 }
 

--- a/src/cslp/types/cslp.types.ts
+++ b/src/cslp/types/cslp.types.ts
@@ -14,6 +14,9 @@ export interface CslpData {
      */
     fieldPathWithIndex: string;
     multipleFieldMetadata: CslpDataMultipleFieldMetadata;
+    instance: {
+        fieldPathWithIndex: string;
+    }
 }
 
 export interface CslpDataMultipleFieldMetadata {

--- a/src/liveEditor/__test__/visualEditorClick.test.ts
+++ b/src/liveEditor/__test__/visualEditorClick.test.ts
@@ -672,6 +672,9 @@ describe("When an element is clicked in visual editor mode", () => {
                             parentDetails: null,
                             index: -1,
                         },
+                        instance: {
+                            fieldPathWithIndex: "rich_text_editor",
+                        },
                     },
                     cslpData: "all_fields.bltapikey.en-us.rich_text_editor",
                 }
@@ -1190,6 +1193,9 @@ describe("When an element is clicked in visual editor mode", () => {
                         multipleFieldMetadata: {
                             parentDetails: null,
                             index: -1,
+                        },
+                        instance: {
+                            fieldPathWithIndex: "markdown",
                         },
                     },
                     cslpData: "all_fields.bltapikey.en-us.markdown",
@@ -2461,6 +2467,9 @@ describe("When an element is clicked in visual editor mode", () => {
                             parentDetails: null,
                             index: -1,
                         },
+                        instance: {
+                            fieldPathWithIndex: "link.href",
+                        }
                     },
                     cslpData: "all_fields.bltapikey.en-us.link.href",
                 }
@@ -2990,6 +2999,9 @@ describe("When an element is clicked in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "group_multiple_.0",
+                        }
                     },
                     cslpData: "all_fields.bltapikey.en-us.group_multiple_.0",
                 }

--- a/src/liveEditor/__test__/visualEditorHover.test.ts
+++ b/src/liveEditor/__test__/visualEditorHover.test.ts
@@ -384,6 +384,10 @@ describe("When an element is hovered in visual editor mode", () => {
                                 parentPath: "single_line_textbox_multiple_",
                             },
                         },
+                        instance: {
+                            fieldPathWithIndex: "single_line_textbox_multiple_.0",
+                        },
+                        }
                     },
                     index: 0,
                 }
@@ -409,6 +413,9 @@ describe("When an element is hovered in visual editor mode", () => {
                                 parentPath: "single_line_textbox_multiple_",
                             },
                         },
+                        instance: {
+                            fieldPathWithIndex: "single_line_textbox_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -590,6 +597,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "multi_line_textbox_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -615,6 +625,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "multi_line_textbox_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -797,6 +810,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "rich_text_editor_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -822,6 +838,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "rich_text_editor_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -1002,6 +1021,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "json_rich_text_editor_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -1027,6 +1049,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "json_rich_text_editor_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -1209,6 +1234,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "markdown_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -1234,6 +1262,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "markdown_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -1414,6 +1445,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "select_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -1439,6 +1473,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "select_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -1617,6 +1654,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "number_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -1642,6 +1682,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "number_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -1913,6 +1956,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "file_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -1938,6 +1984,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "file_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -2200,6 +2249,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "link_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -2225,6 +2277,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "link_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -2403,6 +2458,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "reference_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -2429,6 +2487,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "reference_multiple_.0",
+                        }
                     },
                     index: 1,
                 }
@@ -2657,6 +2718,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "group_multiple_.0",
+                        }
                     },
                     index: 0,
                 }
@@ -2683,6 +2747,9 @@ describe("When an element is hovered in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "group_multiple_.0",
+                        }
                     },
                     index: 1,
                 }

--- a/src/liveEditor/__test__/visualEditorInput.test.ts
+++ b/src/liveEditor/__test__/visualEditorInput.test.ts
@@ -149,6 +149,9 @@ describe("When an inline element is edited in visual editor mode", () => {
                             parentDetails: null,
                             index: -1,
                         },
+                        instance: {
+                            fieldPathWithIndex: "single_line",
+                        }
                     },
                 }
             );
@@ -280,6 +283,9 @@ describe("When an inline element is edited in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "single_line_textbox_multiple_.0",
+                        }
                     },
                 }
             );
@@ -328,6 +334,9 @@ describe("When an inline element is edited in visual editor mode", () => {
                             },
                             index: 1,
                         },
+                        instance: {
+                            fieldPathWithIndex: "single_line_textbox_multiple_.1",
+                        }
                     },
                 }
             );
@@ -420,6 +429,9 @@ describe("When an inline element is edited in visual editor mode", () => {
                             parentDetails: null,
                             index: -1,
                         },
+                        instance: {
+                            fieldPathWithIndex: "multi_line",
+                        }
                     },
                 }
             );
@@ -552,6 +564,9 @@ describe("When an inline element is edited in visual editor mode", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "single_line_textbox_multiple_.0",
+                        }
                     },
                 }
             );
@@ -600,6 +615,9 @@ describe("When an inline element is edited in visual editor mode", () => {
                             },
                             index: 1,
                         },
+                        instance: {
+                            fieldPathWithIndex: "single_line_textbox_multiple_.1",
+                        }
                     },
                 }
             );

--- a/src/liveEditor/components/__tests__/fieldLabelWrapper.test.tsx
+++ b/src/liveEditor/components/__tests__/fieldLabelWrapper.test.tsx
@@ -52,6 +52,9 @@ describe("FieldLabelWrapperComponent", () => {
                 parentCslpValue: "",
             },
         },
+        instance: {
+            fieldPathWithIndex: "",
+        },
     };
 
     const mockEventDetails: VisualEditorCslpEventDetails = {

--- a/src/liveEditor/components/__tests__/multipleFieldToolbar.test.tsx
+++ b/src/liveEditor/components/__tests__/multipleFieldToolbar.test.tsx
@@ -28,6 +28,9 @@ const mockFieldMetadata: CslpData = {
             parentCslpValue: "",
         },
     },
+    instance: {
+        fieldPathWithIndex: "",
+    },
 };
 
 describe("MultipleFieldToolbarComponent", () => {

--- a/src/liveEditor/generators/__test__/generateToolbar.test.ts
+++ b/src/liveEditor/generators/__test__/generateToolbar.test.ts
@@ -52,6 +52,9 @@ describe("appendFieldPathDropdown", () => {
                     parentCslpValue: "",
                 },
             },
+            instance: {
+                fieldPathWithIndex: "",
+            }
         };
 
         mockEventDetails = {

--- a/src/liveEditor/utils/__test__/focusOverlayWrapper.test.ts
+++ b/src/liveEditor/utils/__test__/focusOverlayWrapper.test.ts
@@ -258,6 +258,7 @@ describe("hideFocusOverlay", () => {
                     fieldPathWithIndex: "title",
                     locale: "en-us",
                     multipleFieldMetadata: { index: -1, parentDetails: null },
+                    instance: { fieldPathWithIndex: "title" },
                 },
             }
         );

--- a/src/liveEditor/utils/__test__/getCsDataOfElement.test.ts
+++ b/src/liveEditor/utils/__test__/getCsDataOfElement.test.ts
@@ -79,6 +79,7 @@ describe("getCsDataOfElement", () => {
                 fieldPath: "title",
                 fieldPathWithIndex: "title",
                 multipleFieldMetadata: { parentDetails: null, index: -1 },
+                instance: { fieldPathWithIndex: "title" },
             },
         });
     });
@@ -116,6 +117,7 @@ describe("getCsDataOfElement", () => {
                 fieldPath: "title",
                 fieldPathWithIndex: "title",
                 multipleFieldMetadata: { parentDetails: null, index: -1 },
+                instance: { fieldPathWithIndex: "title" },
             },
         });
     });

--- a/src/liveEditor/utils/__test__/getExpectedFieldData.test.ts
+++ b/src/liveEditor/utils/__test__/getExpectedFieldData.test.ts
@@ -38,6 +38,9 @@ const mockFieldMetadata: CslpData = {
         },
         index: 0,
     },
+    instance: {
+        fieldPathWithIndex: "multi_line_textbox_multiple_.0",
+    },
 };
 
 describe("getExpectedFieldData", () => {
@@ -64,6 +67,9 @@ describe("getExpectedFieldData", () => {
                         },
                         index: 0,
                     },
+                    instance: {
+                        fieldPathWithIndex: "multi_line_textbox_multiple_.0",
+                    }
                 },
             }
         );

--- a/src/liveEditor/utils/__test__/instanceHandler.test.ts
+++ b/src/liveEditor/utils/__test__/instanceHandler.test.ts
@@ -35,6 +35,9 @@ describe("instanceHandlers", () => {
                     parentCslpValue: "",
                 },
             },
+            instance: {
+                fieldPathWithIndex: "",
+            },
         };
 
         await handleDeleteInstance(mockFieldMetadata);
@@ -66,6 +69,9 @@ describe("instanceHandlers", () => {
                     parentPath: "",
                     parentCslpValue: "",
                 },
+            },
+            instance: {
+                fieldPathWithIndex: "",
             },
         };
 

--- a/src/liveEditor/utils/__test__/multipleElementAddButton.test.ts
+++ b/src/liveEditor/utils/__test__/multipleElementAddButton.test.ts
@@ -439,6 +439,10 @@ describe("handleAddButtonsForMultiple", () => {
                             },
                             index: 0,
                         },
+                        instance: {
+                            fieldPathWithIndex: "group.0",
+                        },
+                        }
                     },
                     index: 0,
                 }
@@ -463,6 +467,9 @@ describe("handleAddButtonsForMultiple", () => {
                                     "all_fields.bltapikey.en-us.group",
                             },
                             index: 0,
+                        },
+                        instance: {
+                            fieldPathWithIndex: "group.0",
                         },
                     },
                     index: 1,


### PR DESCRIPTION
SDK's post-message payload now contains an added field, viz.:
```
...
instance: {
  fieldPathWithIndex: <exact-field-path-of-the-field-focused>
}
...
```
We now use this path to focus on fields, particularly important in the case of multiple fields where focussing on a specific field inside an instance earlier did not navigate to that field in schema-form.