### PR TITLE
fix: removed headers key from SDK init data

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install @contentstack/live-preview-utils
 Alternatively, if you want to include the package directly in your website HTML code, use the following command:
 
 ```html
-<script src="https://unpkg.com/@contentstack/live-preview-utils@1.4.2/dist/index.js"></script>
+<script src="https://unpkg.com/@contentstack/live-preview-utils@1.4.3/dist/index.js"></script>
 ```
 
 # Initializing the SDK

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@contentstack/live-preview-utils",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "types": "dist/src/index.d.ts",
     "description": "Contentstack provides the Live Preview SDK to establish a communication channel between the various Contentstack SDKs and your website, transmitting  live changes to the preview pane.",
     "main": "dist/index.js",

--- a/src/__test__/contentstack-live-preview-HOC.test.ts
+++ b/src/__test__/contentstack-live-preview-HOC.test.ts
@@ -219,9 +219,6 @@ describe("Gatsby Data formatter", () => {
     test("should return data in correct format", async () => {
         class stackSdkWithFetch {
             live_preview = {};
-            headers = {
-                api_key: "",
-            };
             content_type_uid = "live_preview_content_type";
             environment = "";
 
@@ -243,9 +240,6 @@ describe("Gatsby Data formatter", () => {
 
         class stackSdkWithFind {
             live_preview = {};
-            headers = {
-                api_key: "",
-            };
             content_type_uid = "live_preview_content_type";
 
             environment = "";

--- a/src/__test__/live-preview.test.ts
+++ b/src/__test__/live-preview.test.ts
@@ -733,9 +733,6 @@ describe("incoming postMessage", () => {
     test("should trigger user onChange function when client-data-send is sent with ssr: false", async () => {
         const mockedStackSdk = {
             live_preview: {},
-            headers: {
-                api_key: "",
-            },
             environment: "",
         };
 

--- a/src/live-preview.ts
+++ b/src/live-preview.ts
@@ -51,9 +51,6 @@ export default class LivePreview {
         },
         stackSdk: {
             live_preview: {},
-            headers: {
-                api_key: "",
-            },
             environment: "",
         },
 

--- a/src/utils/__test__/handleUserConfig.test.ts
+++ b/src/utils/__test__/handleUserConfig.test.ts
@@ -35,9 +35,6 @@ describe("handleInitData()", () => {
             },
             stackSdk: {
                 live_preview: {},
-                headers: {
-                    api_key: "",
-                },
                 environment: "",
             },
 
@@ -76,9 +73,6 @@ describe("handleInitData()", () => {
                 url: "https://app.contentstack.com:443",
             },
             stackSdk: {
-                headers: {
-                    api_key: "",
-                },
                 environment: "",
             },
         };
@@ -91,9 +85,6 @@ describe("handleInitData()", () => {
                 enable: true,
             },
             config: {},
-            headers: {
-                api_key: "bltanything",
-            },
             environment: "",
             cachePolicy: 1,
         };
@@ -104,7 +95,7 @@ describe("handleInitData()", () => {
             enable: true,
             cleanCslpOnProduction: true,
             stackDetails: {
-                apiKey: "bltanything",
+                apiKey: "",
                 environment: "",
                 contentTypeUid: "",
                 entryUid: "",
@@ -120,9 +111,6 @@ describe("handleInitData()", () => {
                     enable: true,
                 },
                 config: {},
-                headers: {
-                    api_key: "bltanything",
-                },
                 environment: "",
                 cachePolicy: 1,
             },
@@ -154,9 +142,6 @@ describe("handleInitData()", () => {
                 live_preview: {
                     enable: true,
                 },
-                headers: {
-                    api_key: "bltanything",
-                },
                 environment: "",
                 cachePolicy: 1,
             },
@@ -170,9 +155,6 @@ describe("handleInitData()", () => {
         const initData: Partial<IStackSdk> = {
             live_preview: {
                 enable: true,
-            },
-            headers: {
-                api_key: "bltanything",
             },
             environment: "",
             cachePolicy: 1,
@@ -218,9 +200,6 @@ describe("handleClientUrlParams()", () => {
             },
             stackSdk: {
                 live_preview: {},
-                headers: {
-                    api_key: "",
-                },
                 environment: "",
             },
 

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -24,9 +24,6 @@ export const userInitData: IInitData = {
     },
     stackSdk: {
         live_preview: {},
-        headers: {
-            api_key: "",
-        },
         environment: "",
     },
     runScriptsOnUpdate: false,

--- a/src/utils/handleUserConfig.ts
+++ b/src/utils/handleUserConfig.ts
@@ -97,11 +97,6 @@ export const handleInitData = (
         config.stackSdk = initData;
 
         // stack details
-        if (
-            Object.prototype.hasOwnProperty.call(initData.headers, "api_key") &&
-            initData.headers.api_key
-        )
-            config.stackDetails.apiKey = initData.headers.api_key;
 
         if (Object.prototype.hasOwnProperty.call(initData, "environment")) {
             config.stackDetails.environment = initData.environment;
@@ -170,9 +165,7 @@ export const handleInitData = (
         };
 
         config.stackDetails.apiKey =
-            initData.stackDetails?.apiKey ??
-            stackSdk.headers?.api_key ??
-            config.stackDetails.apiKey;
+            initData.stackDetails?.apiKey ?? config.stackDetails.apiKey;
 
         config.stackDetails.environment =
             initData.stackDetails?.environment ??

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -18,9 +18,6 @@ export declare interface IClientUrlParams {
 export declare interface IStackSdk {
     live_preview: { [key: string]: any } & Partial<IConfig>;
     [key: string]: any;
-    headers: {
-        api_key: string;
-    };
     environment: string;
 }
 


### PR DESCRIPTION
fix: removed headers key from SDK init data as it no longer supports)in contentstack SDK
Ticket -> https://contentstack.atlassian.net/browse/VE-1541