### PR TITLE
Fix the bug that caused wrong fieldWrapper parent tags above blocks of a modularblock field

### DIFF
--- a/src/liveEditor/components/fieldLabelWrapper.tsx
+++ b/src/liveEditor/components/fieldLabelWrapper.tsx
@@ -7,6 +7,7 @@ import { FieldSchemaMap } from "../utils/fieldSchemaMap";
 import { isFieldDisabled } from "../utils/isFieldDisabled";
 import { CaretIcon, InfoIcon } from "./icons";
 import { extractDetailsFromCslp } from "../../cslp";
+import { getFieldPathWithUid } from "../utils/getFieldPathWithUid";
 
 interface FieldLabelWrapperProps {
     fieldMetadata: CslpData;
@@ -58,8 +59,9 @@ function FieldLabelWrapperComponent(
 
             const displayNames = await Promise.all(
                 props.parentPaths.map(async (path) => {
+                    const pathWithUid = await getFieldPathWithUid(path);
                     const { content_type_uid, fieldPath } =
-                        extractDetailsFromCslp(path);
+                        extractDetailsFromCslp(pathWithUid);
                     const fieldSchema = await FieldSchemaMap.getFieldSchema(
                         content_type_uid,
                         fieldPath

--- a/src/liveEditor/utils/getFieldPathWithUid.ts
+++ b/src/liveEditor/utils/getFieldPathWithUid.ts
@@ -1,0 +1,21 @@
+import { toString } from "lodash-es";
+import liveEditorPostMessage from "./liveEditorPostMessage";
+import { LiveEditorPostMessageEvents } from "./types/postMessage.types";
+
+/**
+ * Retrieves the actual fieldPath along with the fieldUid
+ *
+ * @param fieldMetadata The metadata of the field.
+ * @param path The cslp path of the field.
+ * @returns A promise that resolves to the expected fieldPath with uid as a string.
+ */
+export async function getFieldPathWithUid(
+    path: string,
+): Promise<string> {
+    const data = await liveEditorPostMessage?.send<{ fieldPathWithUid: unknown }>(
+        LiveEditorPostMessageEvents.GET_FIELD_PATH_WITH_UID,
+        { path }
+    );
+
+    return toString(data?.fieldPathWithUid);
+}

--- a/src/liveEditor/utils/types/postMessage.types.ts
+++ b/src/liveEditor/utils/types/postMessage.types.ts
@@ -6,6 +6,7 @@ export enum LiveEditorPostMessageEvents {
     OPEN_QUICK_FORM = "open-quick-form",
     GET_FIELD_SCHEMA = "get-field-schema",
     GET_FIELD_DATA = "get-field-data",
+    GET_FIELD_PATH_WITH_UID = "get-field-path-with-uid",
     FOCUS_FIELD = "focus-field",
     DELETE_INSTANCE = "delete-instance",
     MOVE_INSTANCE = "move-instance",


### PR DESCRIPTION
Ticket: https://contentstack.atlassian.net/browse/VE-2048

To retrieve the fieldUid, to be able to display the correct name, entry was needed. For that, a new postmessage event is introduced that retrieves the fieldUid in the path of parent blocks, from visual editor.