### PR TITLE
chore: bump version for version compatibility with UI-React LP 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@contentstack/live-preview-utils",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@contentstack/live-preview-utils",
-            "version": "1.4.0",
+            "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@contentstack/live-preview-utils",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "types": "dist/src/index.d.ts",
     "description": "Contentstack provides the Live Preview SDK to establish a communication channel between the various Contentstack SDKs and your website, transmitting  live changes to the preview pane.",
     "main": "dist/index.js",


### PR DESCRIPTION
1. UI-React branch https://github.com/contentstack/UI-React/tree/EB-1087-implement-live-preview-2-changes adds adv-post-message for LP related messaging
2. Bumping the SDK version passes the version compatibility check required for the internal usage of adv-post-message in UI-React.