### PR TITLE
fix: single line line break and unnecessary psuedo editable due to nbsp

### DIFF
--- a/src/liveEditor/components/pseudoEditableField.tsx
+++ b/src/liveEditor/components/pseudoEditableField.tsx
@@ -19,6 +19,9 @@ function PseudoEditableFieldComponent(
     styles.position = "absolute";
     styles.top = `${offsetTop}px`;
     styles.left = `${offsetLeft}px`;
+    // setting height to auto so that the element can grow based on the content
+    // and the resize observer can detect the change in height
+    styles.height = "auto";
 
     return (
         <div

--- a/src/liveEditor/generators/generateOverlay.tsx
+++ b/src/liveEditor/generators/generateOverlay.tsx
@@ -15,7 +15,7 @@ import EventListenerHandlerParams from "../listeners/types";
 export function addFocusOverlay(
     targetElement: Element,
     focusOverlayWrapper: HTMLDivElement,
-    disabled?: boolean,
+    disabled?: boolean
 ): void {
     const targetElementDimension = targetElement.getBoundingClientRect();
 
@@ -37,11 +37,14 @@ export function addFocusOverlay(
         ".visual-editor__overlay--bottom"
     );
     if (bottomOverlayDOM) {
-        bottomOverlayDOM.style.top = `${targetElementDimension.bottom + window.scrollY}px`;
-        bottomOverlayDOM.style.height = `${window.document.body.scrollHeight -
+        bottomOverlayDOM.style.top = `${
+            targetElementDimension.bottom + window.scrollY
+        }px`;
+        bottomOverlayDOM.style.height = `${
+            window.document.body.scrollHeight -
             targetElementDimension.bottom -
             window.scrollY
-            }px`;
+        }px`;
         bottomOverlayDOM.style.left = "0";
         bottomOverlayDOM.style.width = "100%";
     }
@@ -63,14 +66,18 @@ export function addFocusOverlay(
         rightOverlayDOM.style.left = `${targetElementDimension.right}px`;
         rightOverlayDOM.style.top = `${distanceFromTop}px`;
         rightOverlayDOM.style.height = `${targetElementDimension.height}px`;
-        rightOverlayDOM.style.width = `${document.documentElement.clientWidth - targetElementDimension.right}px`;
+        rightOverlayDOM.style.width = `${
+            document.documentElement.clientWidth - targetElementDimension.right
+        }px`;
     }
 
     const outlineDOM = focusOverlayWrapper.querySelector<HTMLDivElement>(
         ".visual-editor__overlay--outline"
     );
     if (outlineDOM) {
-        outlineDOM.style.top = `${targetElementDimension.top + window.scrollY}px`;
+        outlineDOM.style.top = `${
+            targetElementDimension.top + window.scrollY
+        }px`;
         outlineDOM.style.height = `${targetElementDimension.height}px`;
         outlineDOM.style.width = `${targetElementDimension.width}px`;
         outlineDOM.style.left = `${targetElementDimension.left}px`;
@@ -83,15 +90,12 @@ export function addFocusOverlay(
  * @param event - The mouse event that triggered the function.
  * @param elements - An object containing references to the focus overlay wrapper, the previously selected editable DOM element, and the visual editor wrapper.
  */
-export function hideFocusOverlay(elements: {
-    visualEditorContainer: HTMLDivElement | null;
-    visualEditorOverlayWrapper: HTMLDivElement | null;
-    focusedToolbar: HTMLDivElement | null;
-}): void {
+export function hideFocusOverlay(elements: HideOverlayParams): void {
     const {
         visualEditorContainer,
         visualEditorOverlayWrapper,
         focusedToolbar,
+        resizeObserver,
     } = elements;
 
     if (visualEditorOverlayWrapper) {
@@ -136,6 +140,7 @@ export function hideFocusOverlay(elements: {
                 overlayWrapper: visualEditorOverlayWrapper,
                 visualEditorContainer: visualEditorContainer,
                 focusedToolbar: focusedToolbar,
+                resizeObserver: resizeObserver,
             });
         }
     }
@@ -154,6 +159,7 @@ export function hideOverlay(params: HideOverlayParams): void {
         visualEditorContainer: params.visualEditorContainer,
         visualEditorOverlayWrapper: params.visualEditorOverlayWrapper,
         focusedToolbar: params.focusedToolbar,
+        resizeObserver: params.resizeObserver,
     });
 
     if (!VisualEditor.VisualEditorGlobalState.value.previousSelectedEditableDOM)

--- a/src/liveEditor/listeners/mouseClick.ts
+++ b/src/liveEditor/listeners/mouseClick.ts
@@ -94,7 +94,21 @@ async function handleEditorInteraction(
             overlayWrapper: params.overlayWrapper,
             visualEditorContainer: params.visualEditorContainer,
             focusedToolbar: params.focusedToolbar,
+            resizeObserver: params.resizeObserver,
         });
+    }
+
+    // when previous and current selected element is same, return.
+    // this also avoids inserting psuedo-editable field (field data is
+    // not equal to text content in DOM) when performing mouse
+    // selections in the content editable
+    const previousSelectedElement =
+        VisualEditor.VisualEditorGlobalState.value.previousSelectedEditableDOM;
+    if (
+        previousSelectedElement &&
+        previousSelectedElement === editableElement
+    ) {
+        return;
     }
 
     if (
@@ -158,6 +172,7 @@ async function handleEditorInteraction(
 
     await handleIndividualFields(eventDetails, {
         visualEditorContainer: params.visualEditorContainer,
+        resizeObserver: params.resizeObserver,
         lastEditedField:
             VisualEditor.VisualEditorGlobalState.value
                 .previousSelectedEditableDOM,

--- a/src/liveEditor/utils/handleFieldMouseDown.ts
+++ b/src/liveEditor/utils/handleFieldMouseDown.ts
@@ -21,6 +21,14 @@ export function handleFieldKeyDown(e: Event): void {
 
     if (fieldType === FieldDataType.NUMBER) {
         handleNumericFieldKeyDown(event);
+    } else if (fieldType === FieldDataType.SINGLELINE) {
+        handleSingleLineFieldKeyDown(event);
+    }
+}
+
+function handleSingleLineFieldKeyDown(e: KeyboardEvent) {
+    if (e.code === "Enter") {
+        e.preventDefault();
     }
 }
 

--- a/src/liveEditor/utils/normalizeNonBreakingSpace.ts
+++ b/src/liveEditor/utils/normalizeNonBreakingSpace.ts
@@ -1,0 +1,3 @@
+export function normalizeNonBreakingSpace(text: string): string {
+    return text.replace("&nbsp;", " ").replace(/\s+/g, " ");
+}


### PR DESCRIPTION
Fixes [VE-2182](https://contentstack.atlassian.net/browse/VE-2182)
1. Non-breaking space inserted on editing in content editable leads to unnecessary psuedo editable elements being inserted. Nbsp is now normalized to a standard whitespace.
2. Psuedo editable element was not being observed so new lines did not trigger an overlay update. The observer now observes and unobserves the psuedo editable correctly.
3. Enter is now disallowed for single line field type to match the standard text input

[VE-2182]: https://contentstack.atlassian.net/browse/VE-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ