### PR TITLE
feat: update focussed state and misc. improvements

### DIFF
--- a/src/liveEditor/components/__tests__/fieldLabelWrapper.test.tsx
+++ b/src/liveEditor/components/__tests__/fieldLabelWrapper.test.tsx
@@ -63,6 +63,8 @@ describe("FieldLabelWrapperComponent", () => {
         fieldMetadata: mockFieldMetadata,
     };
 
+    const mockGetParentEditable = () => document.createElement("div");
+
     test("renders current field and parent fields correctly", async () => {
         const parentPaths = ["parentPath1", "parentPath2", "parentPath3"];
 
@@ -71,6 +73,7 @@ describe("FieldLabelWrapperComponent", () => {
                 fieldMetadata={mockFieldMetadata}
                 eventDetails={mockEventDetails}
                 parentPaths={parentPaths}
+                getParentEditableElement={mockGetParentEditable}
             />
         );
 
@@ -88,6 +91,7 @@ describe("FieldLabelWrapperComponent", () => {
                 fieldMetadata={mockFieldMetadata}
                 eventDetails={mockEventDetails}
                 parentPaths={[]}
+                getParentEditableElement={mockGetParentEditable}
             />
         );
 
@@ -100,6 +104,7 @@ describe("FieldLabelWrapperComponent", () => {
                 fieldMetadata={mockFieldMetadata}
                 eventDetails={mockEventDetails}
                 parentPaths={[]}
+                getParentEditableElement={mockGetParentEditable}
             />
         );
         await waitFor(() => {

--- a/src/liveEditor/components/fieldLabelWrapper.tsx
+++ b/src/liveEditor/components/fieldLabelWrapper.tsx
@@ -22,6 +22,7 @@ interface FieldLabelWrapperProps {
     fieldMetadata: CslpData;
     eventDetails: VisualEditorCslpEventDetails;
     parentPaths: string[];
+    getParentEditableElement: (cslp: string) => HTMLElement | null;
 }
 
 function FieldLabelWrapperComponent(
@@ -35,6 +36,7 @@ function FieldLabelWrapperComponent(
     const [displayNames, setDisplayNames] = useState<Record<string, string>>(
         {}
     );
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
     function calculateTopOffset(index: number) {
         const height = -30; // from bottom
@@ -90,6 +92,14 @@ function FieldLabelWrapperComponent(
         Object.values(displayNames).length < props.parentPaths.length + 1
     );
 
+    const onParentPathClick = (cslp: string) => {
+        const parentElement = props.getParentEditableElement(cslp);
+        if (parentElement) {
+            // emulate clicking on the parent element
+            parentElement.click();
+        }
+    };
+
     return (
         <div
             className={classNames(
@@ -97,8 +107,12 @@ function FieldLabelWrapperComponent(
                 {
                     "visual-editor__focused-toolbar--field-disabled":
                         currentField.disabled,
+                },
+                {
+                    "field-label-dropdown-open": isDropdownOpen,
                 }
             )}
+            onClick={() => setIsDropdownOpen((prev) => !prev)}
         >
             <button
                 className="visual-editor__focused-toolbar__field-label-wrapper__current-field visual-editor__button visual-editor__button--primary"
@@ -117,6 +131,7 @@ function FieldLabelWrapperComponent(
                     className="visual-editor__focused-toolbar__field-label-wrapper__parent-field visual-editor__button visual-editor__button--secondary visual-editor__focused-toolbar__text"
                     data-target-cslp={path}
                     style={{ top: calculateTopOffset(index) }}
+                    onClick={() => onParentPathClick(path)}
                 >
                     {displayNames[path]}
                 </button>

--- a/src/liveEditor/generators/generateHoverOutline.tsx
+++ b/src/liveEditor/generators/generateHoverOutline.tsx
@@ -25,6 +25,7 @@ export function addHoverOutline(
   const hoverOutline = document.querySelector<HTMLDivElement>(".visual-editor__hover-outline");
 
   if (hoverOutline) {
+    hoverOutline.classList.remove("visual-editor__hover-outline--hidden");
 
     if(isAnchorElement){
       const cslpValue = targetElement.getAttribute('data-cslp') || '';

--- a/src/liveEditor/generators/generateToolbar.tsx
+++ b/src/liveEditor/generators/generateToolbar.tsx
@@ -73,49 +73,17 @@ export function appendFieldPathDropdown(
             fieldMetadata={fieldMetadata}
             eventDetails={eventDetails}
             parentPaths={parentPaths}
+            getParentEditableElement={(cslp: string) => {
+                const parentElement = targetElement.closest(
+                    `[${DATA_CSLP_ATTR_SELECTOR}="${cslp}"]`
+                ) as HTMLElement | null;
+                return parentElement;
+            }}
         />,
         wrapper
     );
 
     focusedToolbarElement.appendChild(wrapper);
-
-    const FieldLabelWrapper = focusedToolbarElement.querySelector(
-        ".visual-editor__focused-toolbar__field-label-wrapper"
-    );
-
-    focusedToolbarElement.addEventListener("click", (e) => {
-        e.preventDefault();
-
-        if (
-            (e.target as Element).classList.contains("visual-editor__tooltip")
-        ) {
-            return;
-        }
-        if (
-            (e.target as Element).classList.contains(
-                "visual-editor__focused-toolbar__field-label-wrapper__parent-field"
-            )
-        ) {
-            const cslp = (e.target as Element).getAttribute(
-                "data-target-cslp"
-            ) as string;
-            const parentElement = targetElement.closest(
-                `[${DATA_CSLP_ATTR_SELECTOR}="${cslp}"]`
-            ) as HTMLElement;
-            if (parentElement) {
-                parentElement.click();
-            }
-            return;
-        }
-
-        if (
-            FieldLabelWrapper?.classList.contains("field-label-dropdown-open")
-        ) {
-            FieldLabelWrapper?.classList.remove("field-label-dropdown-open");
-            return;
-        }
-        FieldLabelWrapper?.classList.add("field-label-dropdown-open");
-    });
 }
 
 function collectParentCSLPPaths(

--- a/src/liveEditor/listeners/index.ts
+++ b/src/liveEditor/listeners/index.ts
@@ -3,6 +3,7 @@ import { VisualEditor } from "..";
 import handleEditorInteraction from "./mouseClick";
 import handleMouseHover, {
     hideCustomCursor,
+    hideHoverOutline,
     showCustomCursor,
 } from "./mouseHover";
 
@@ -41,6 +42,7 @@ export function addEventListeners(params: AddEventListenersParams): void {
 
     document.documentElement.addEventListener("mouseleave", () => {
         hideCustomCursor(params.customCursor);
+        hideHoverOutline(params.visualEditorContainer);
     });
 
     document.documentElement.addEventListener("mouseenter", () => {

--- a/src/liveEditor/listeners/mouseClick.ts
+++ b/src/liveEditor/listeners/mouseClick.ts
@@ -51,7 +51,7 @@ function addOverlay(params: AddFocusOverlayParams) {
     params.resizeObserver.observe(params.editableElement);
 }
 
-function addFocusedToolbar(params: AddFocusedToolbarParams) {
+export function addFocusedToolbar(params: AddFocusedToolbarParams): void {
     const { editableElement } = params.eventDetails;
 
     if (!editableElement || !params.focusedToolbar) return;

--- a/src/liveEditor/listeners/mouseHover.ts
+++ b/src/liveEditor/listeners/mouseHover.ts
@@ -75,6 +75,21 @@ function showDefaultCursor(): void {
         );
 }
 
+export function hideHoverOutline(
+    visualEditorContainer: HTMLDivElement | null
+): void {
+    if (!visualEditorContainer) {
+        return;
+    }
+    const hoverOutline = visualEditorContainer.querySelector(
+        ".visual-editor__hover-outline"
+    );
+    if (!hoverOutline) {
+        return;
+    }
+    hoverOutline.classList.add("visual-editor__hover-outline--hidden");
+}
+
 export function hideCustomCursor(customCursor: HTMLDivElement | null): void {
     showDefaultCursor();
     customCursor?.classList.remove("visible");

--- a/src/liveEditor/utils/constants.ts
+++ b/src/liveEditor/utils/constants.ts
@@ -29,7 +29,7 @@ export const ALLOWED_MODAL_EDITABLE_FIELD: FieldDataType[] = [
     FieldDataType.ISODATE,
 ];
 
-// TODO - migrate asset here as well
 export const ALLOWED_REPLACE_FIELDS: FieldDataType[] = [
     FieldDataType.REFERENCE,
+    FieldDataType.FILE,
 ];

--- a/src/liveEditor/utils/updateFocussedState.ts
+++ b/src/liveEditor/utils/updateFocussedState.ts
@@ -1,0 +1,121 @@
+import { VisualEditor } from "..";
+import { extractDetailsFromCslp } from "../../cslp";
+import { getAddInstanceButtons } from "../generators/generateAddInstanceButtons";
+import { addFocusOverlay } from "../generators/generateOverlay";
+import { appendFocusedToolbar } from "../generators/generateToolbar";
+import { hideHoverOutline } from "../listeners/mouseHover";
+import getChildrenDirection from "./getChildrenDirection";
+import getStyleOfAnElement from "./getStyleOfAnElement";
+
+/**
+ * This function can be used to re-draw/update the focussed state of an element.
+ * The focussed state includes the overlay, psuedo-editable, toolbar, and multiple
+ * instance add buttons. It is similar to handleEditorInteraction but it does not
+ * create new elements, it just updates the existing ones whenever possible.
+ * NOTE: breakdown this function into multiple functions when the need arises
+ */
+export function updateFocussedState({
+    editableElement,
+    visualEditorContainer,
+    overlayWrapper,
+    focusedToolbar,
+    resizeObserver,
+}: {
+    editableElement: HTMLElement | null;
+    visualEditorContainer: HTMLDivElement | null;
+    overlayWrapper: HTMLDivElement | null;
+    focusedToolbar: HTMLDivElement | null;
+    resizeObserver: ResizeObserver;
+}): void {
+    const previousSelectedEditableDOM =
+        VisualEditor.VisualEditorGlobalState.value.previousSelectedEditableDOM;
+    if (
+        !visualEditorContainer ||
+        !editableElement ||
+        !previousSelectedEditableDOM ||
+        !overlayWrapper
+    ) {
+        return;
+    }
+    hideHoverOutline(visualEditorContainer);
+    addFocusOverlay(previousSelectedEditableDOM, overlayWrapper);
+
+    // update psuedo editable element if present
+    const psuedoEditableElement = visualEditorContainer.querySelector(
+        ".visual-editor__pseudo-editable-element"
+    ) as HTMLElement;
+    if (psuedoEditableElement) {
+        const styles = getStyleOfAnElement(editableElement);
+        const styleString = Object.entries(styles).reduce(
+            (acc, [key, value]) => {
+                return `${acc}${key}:${value};`;
+            },
+            ""
+        );
+        psuedoEditableElement.style.cssText = styleString;
+        psuedoEditableElement.style.visibility = "visible";
+        psuedoEditableElement.style.position = "absolute";
+        psuedoEditableElement.style.top = `${editableElement.offsetTop}px`;
+        psuedoEditableElement.style.left = `${editableElement.offsetLeft}px`;
+    }
+
+    const cslp = editableElement?.getAttribute("data-cslp") || "";
+    const fieldMetadata = extractDetailsFromCslp(cslp);
+
+    // re-add focussed toolbar
+    if (focusedToolbar) {
+        focusedToolbar.innerHTML = "";
+    }
+    appendFocusedToolbar(
+        {
+            editableElement: editableElement as HTMLElement,
+            cslpData: cslp,
+            fieldMetadata,
+        },
+        focusedToolbar as HTMLDivElement
+    );
+
+    // re-add multiple instance add buttons
+    const buttons = getAddInstanceButtons(visualEditorContainer);
+    const parentCslpValue =
+        fieldMetadata.multipleFieldMetadata?.parentDetails?.parentCslpValue;
+    if (
+        buttons &&
+        parentCslpValue &&
+        buttons.length > 1 &&
+        buttons[0] &&
+        buttons[1]
+    ) {
+        const [previousButton, nextButton] = buttons;
+        const direction = getChildrenDirection(
+            editableElement,
+            parentCslpValue
+        );
+        const targetDOMDimension = editableElement.getBoundingClientRect();
+
+        if (direction === "horizontal") {
+            const middleHeight =
+                targetDOMDimension.top +
+                (targetDOMDimension.bottom - targetDOMDimension.top) / 2 +
+                window.scrollY;
+            previousButton.style.left = `${targetDOMDimension.left}px`;
+            previousButton.style.top = `${middleHeight}px`;
+
+            nextButton.style.left = `${targetDOMDimension.right}px`;
+            nextButton.style.top = `${middleHeight}px`;
+        } else if (direction === "vertical") {
+            const middleWidth =
+                targetDOMDimension.left +
+                (targetDOMDimension.right - targetDOMDimension.left) / 2;
+            previousButton.style.left = `${middleWidth}px`;
+            previousButton.style.top = `${
+                targetDOMDimension.top + window.scrollY
+            }px`;
+
+            nextButton.style.left = `${middleWidth}px`;
+            nextButton.style.top = `${
+                targetDOMDimension.bottom + window.scrollY
+            }px`;
+        }
+    }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,7 @@
+.visual-editor__container {
+    --outline-transition: all 0.15s ease-in;
+}
+
 .cslp-edit-mode {
     outline: 1px dashed #6c5ce7 !important;
     position: relative !important;
@@ -117,7 +121,7 @@ div.multiple div.cslp-tooltip-child:hover:before {
 .visual-editor__overlay--outline {
     position: absolute;
     outline: 4px solid #715cdd;
-    transition: all 0.2s ease-in;
+    transition: var(--outline-transition);
 }
 .visual-editor__overlay__wrapper.visible {
     visibility: visible;
@@ -127,7 +131,7 @@ div.multiple div.cslp-tooltip-child:hover:before {
     box-sizing: content-box;
     pointer-events: all;
     position: absolute;
-    transition: all 0.2s ease-in;
+    transition: var(--outline-transition);
 }
 .cslp-tooltip {
     /* visibility: hidden; */
@@ -151,6 +155,8 @@ div.multiple div.cslp-tooltip-child:hover:before {
     justify-content: center;
 
     z-index: 200;
+
+    transition: var(--outline-transition);
 }
 .visual-editor__start-editing-btn {
     text-decoration: none;
@@ -232,6 +238,7 @@ div.multiple div.cslp-tooltip-child:hover:before {
     width: 0;
     display: flex;
     align-items: end;
+    transition: var(--outline-transition);
 }
 
 .visual-editor__focused-toolbar__field-label-wrapper__current-field {
@@ -456,7 +463,11 @@ div.multiple div.cslp-tooltip-child:hover:before {
 .visual-editor__hover-outline {
     position: absolute;
     outline: 2px dashed #6c5ce7;
-    transition: all 0.2s ease-in;
+    transition: var(--outline-transition);
+}
+
+.visual-editor__hover-outline--hidden {
+    visibility: hidden;
 }
 
 .visual-editor__hover-outline--unclickable {


### PR DESCRIPTION
Fixes: [VE-2250](https://contentstack.atlassian.net/browse/VE-2250)
- Update focussed state - toolbar (fieldpath dropdown and edit/replace buttons), overlays, overlay outline, psuedo editable on element resize.
- Some other improvements like setting up event listeners in fieldpath toolbar Preact component instead of adding a generic listener on parent wrapper; removing hover outline on mouseout, unobserving elements on cleanup.

[VE-2250]: https://contentstack.atlassian.net/browse/VE-2250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ