### PR TITLE
fix: multiple instance added at incorrect index

### DIFF
--- a/src/liveEditor/listeners/mouseClick.ts
+++ b/src/liveEditor/listeners/mouseClick.ts
@@ -19,10 +19,6 @@ import { LiveEditorPostMessageEvents } from "../utils/types/postMessage.types";
 import EventListenerHandlerParams from "./types";
 import { VisualEditor } from "..";
 import { FieldSchemaMap } from "../utils/fieldSchemaMap";
-import {
-    handleAddButtonsForMultiple,
-    removeAddInstanceButtons,
-} from "../utils/multipleElementAddButton";
 import { isFieldDisabled } from "../utils/isFieldDisabled";
 
 type HandleEditorInteractionParams = Omit<
@@ -139,25 +135,28 @@ async function handleEditorInteraction(
             });
         }
 
-        if (
-            fieldSchema.data_type === "block" ||
-            fieldSchema.multiple ||
-            (fieldSchema.data_type === "reference" &&
-                // @ts-ignore
-                fieldSchema.field_metadata.ref_multiple)
-        ) {
-            handleAddButtonsForMultiple(eventDetails, {
-                editableElement: editableElement,
-                visualEditorContainer: params.visualEditorContainer,
-                resizeObserver: params.resizeObserver,
-            });
-        } else {
-            removeAddInstanceButtons({
-                eventTarget: params.event.target,
-                visualEditorContainer: params.visualEditorContainer,
-                overlayWrapper: params.overlayWrapper,
-            });
-        }
+        // This is most probably redundant code, as the handleIndividualFields function
+        // takes care of this
+        // TODO: Remove this
+        // if (
+        //     fieldSchema.data_type === "block" ||
+        //     fieldSchema.multiple ||
+        //     (fieldSchema.data_type === "reference" &&
+        //         // @ts-ignore
+        //         fieldSchema.field_metadata.ref_multiple)
+        // ) {
+        //     handleAddButtonsForMultiple(eventDetails, {
+        //         editableElement: editableElement,
+        //         visualEditorContainer: params.visualEditorContainer,
+        //         resizeObserver: params.resizeObserver,
+        //     });
+        // } else {
+        //     removeAddInstanceButtons({
+        //         eventTarget: params.event.target,
+        //         visualEditorContainer: params.visualEditorContainer,
+        //         overlayWrapper: params.overlayWrapper,
+        //     });
+        // }
     }
 
     liveEditorPostMessage?.send(LiveEditorPostMessageEvents.FOCUS_FIELD, {

--- a/src/liveEditor/utils/getExpectedFieldData.ts
+++ b/src/liveEditor/utils/getExpectedFieldData.ts
@@ -1,4 +1,3 @@
-import { toString } from "lodash-es";
 import { CslpData } from "../../cslp/types/cslp.types";
 import liveEditorPostMessage from "../utils/liveEditorPostMessage";
 import { LiveEditorPostMessageEvents } from "../utils/types/postMessage.types";
@@ -7,15 +6,19 @@ import { LiveEditorPostMessageEvents } from "../utils/types/postMessage.types";
  * Retrieves the expected field data based on the provided field metadata.
  *
  * @param fieldMetadata The metadata of the field.
+ * @param entryPath The path in the entry for which the value must be returned.
  * @returns A promise that resolves to the expected field data as a string.
  */
-export async function getExpectedFieldData(
-    fieldMetadata: CslpData
-): Promise<string> {
+export async function getFieldData(
+    fieldMetadata: Pick<CslpData, "content_type_uid" | "entry_uid" | "locale">,
+    entryPath?: string
+): Promise<any> {
     const data = await liveEditorPostMessage?.send<{ fieldData: unknown }>(
         LiveEditorPostMessageEvents.GET_FIELD_DATA,
-        { fieldMetadata }
+        { fieldMetadata, entryPath: entryPath ?? "" }
     );
 
-    return toString(data?.fieldData);
+    // toString from lodash
+    // return toString(data?.fieldData);
+    return data?.fieldData;
 }

--- a/src/liveEditor/utils/getFieldData.ts
+++ b/src/liveEditor/utils/getFieldData.ts
@@ -1,6 +1,6 @@
 import { CslpData } from "../../cslp/types/cslp.types";
-import liveEditorPostMessage from "../utils/liveEditorPostMessage";
-import { LiveEditorPostMessageEvents } from "../utils/types/postMessage.types";
+import liveEditorPostMessage from "./liveEditorPostMessage";
+import { LiveEditorPostMessageEvents } from "./types/postMessage.types";
 
 /**
  * Retrieves the expected field data based on the provided field metadata.

--- a/src/liveEditor/utils/handleIndividualFields.ts
+++ b/src/liveEditor/utils/handleIndividualFields.ts
@@ -9,7 +9,7 @@ import {
     LIVE_EDITOR_FIELD_TYPE_ATTRIBUTE_KEY,
 } from "./constants";
 import { FieldSchemaMap } from "./fieldSchemaMap";
-import { getFieldData } from "./getExpectedFieldData";
+import { getFieldData } from "./getFieldData";
 import { getFieldType } from "./getFieldType";
 import { handleFieldInput, handleFieldKeyDown } from "./handleFieldMouseDown";
 import { isFieldDisabled } from "./isFieldDisabled";

--- a/src/liveEditor/utils/handleIndividualFields.ts
+++ b/src/liveEditor/utils/handleIndividualFields.ts
@@ -1,9 +1,5 @@
 import { VisualEditor } from "..";
 import {
-    generateReplaceAssetButton,
-    removeReplaceAssetButton,
-} from "../generators/generateAssetButton";
-import {
     generatePseudoEditableElement,
     isEllipsisActive,
 } from "../generators/generatePseudoEditableField";
@@ -13,7 +9,7 @@ import {
     LIVE_EDITOR_FIELD_TYPE_ATTRIBUTE_KEY,
 } from "./constants";
 import { FieldSchemaMap } from "./fieldSchemaMap";
-import { getExpectedFieldData } from "./getExpectedFieldData";
+import { getFieldData } from "./getExpectedFieldData";
 import { getFieldType } from "./getFieldType";
 import { handleFieldInput, handleFieldKeyDown } from "./handleFieldMouseDown";
 import { isFieldDisabled } from "./isFieldDisabled";
@@ -40,11 +36,23 @@ export async function handleIndividualFields(
 ): Promise<void> {
     const { fieldMetadata, editableElement } = eventDetails;
     const { visualEditorContainer, lastEditedField, resizeObserver } = elements;
-    const { content_type_uid, fieldPath } = fieldMetadata;
+    const {
+        content_type_uid,
+        entry_uid,
+        locale,
+        fieldPath,
+        fieldPathWithIndex,
+    } = fieldMetadata;
 
+    // if the fieldPathWithIndex is the same as instance fieldPathWithIndex, it indicates
+    // that the whole multiple field is selected and we need the value of the whole multiple field
+    const entryPath =
+        fieldPathWithIndex === fieldMetadata.instance.fieldPathWithIndex
+            ? fieldPathWithIndex
+            : fieldMetadata.instance.fieldPathWithIndex;
     const [fieldSchema, expectedFieldData] = await Promise.all([
         FieldSchemaMap.getFieldSchema(content_type_uid, fieldPath),
-        getExpectedFieldData(fieldMetadata),
+        getFieldData({ content_type_uid, entry_uid, locale }, entryPath),
     ]);
 
     const fieldType = getFieldType(fieldSchema);
@@ -64,12 +72,18 @@ export async function handleIndividualFields(
             fieldSchema.field_metadata.ref_multiple)
     ) {
         if (lastEditedField !== editableElement) {
-            // TODO this internally does a getFieldSchema message again, which is not necessary
-            handleAddButtonsForMultiple(eventDetails, {
-                editableElement: eventDetails.editableElement,
-                visualEditorContainer: visualEditorContainer,
-                resizeObserver: resizeObserver,
-            });
+            handleAddButtonsForMultiple(
+                eventDetails,
+                {
+                    editableElement: eventDetails.editableElement,
+                    visualEditorContainer: visualEditorContainer,
+                    resizeObserver: resizeObserver,
+                },
+                {
+                    expectedFieldData,
+                    disabled,
+                }
+            );
         }
 
         // * fields could be handled as they are in a single instance
@@ -198,6 +212,8 @@ export function cleanIndividualFieldResidual(elements: {
             handleFieldKeyDown
         );
 
+        // Note - this happens in two places, 1. hideOverlay and 2. here
+        // TODO maybe see all usages of both functions and try to do it in one place
         elements.resizeObserver.unobserve(previousSelectedEditableDOM);
     }
 

--- a/src/liveEditor/utils/normalizeNonBreakingSpace.ts
+++ b/src/liveEditor/utils/normalizeNonBreakingSpace.ts
@@ -1,3 +1,4 @@
 export function normalizeNonBreakingSpace(text: string): string {
-    return text.replace("&nbsp;", " ").replace(/\s+/g, " ");
+    // replace non-breaking space with space and normalize all whitespace chars (not \n \r)
+    return text.replace("&nbsp;", " ").replace(/[^\S\r\n]/gm, " ");
 }


### PR DESCRIPTION
Fixes [VE-2308](https://contentstack.atlassian.net/browse/VE-2308)
- Multiple instances are added at wrong index when the whole multiple field is selected instead of a particular index.
- We already fetch the field value, but we always fetched an instance value, the `getExpectedData --> getFieldData` now supports any path and can also return an object.
- Then, we can use `fieldValue.length` to specify the end index when the whole multiple field is selected.

[VE-2308]: https://contentstack.atlassian.net/browse/VE-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ