### PR TITLE
Multiline Field Support

### DIFF
--- a/src/liveEditor/components/pseudoEditableField.tsx
+++ b/src/liveEditor/components/pseudoEditableField.tsx
@@ -22,6 +22,7 @@ function PseudoEditableFieldComponent(
     // setting height to auto so that the element can grow based on the content
     // and the resize observer can detect the change in height
     styles.height = "auto";
+    styles.whiteSpace = "pre-line"
 
     return (
         <div

--- a/src/liveEditor/utils/getMultilinePlaintext.ts
+++ b/src/liveEditor/utils/getMultilinePlaintext.ts
@@ -1,0 +1,42 @@
+
+export function getMultilinePlaintext(editableElement: Element): string {
+  let newValue = '';
+  let isOnFreshLine = true;
+
+  // Recursive function to navigate childNodes and build linebreaks with text
+  function parseChildNodesForValueAndLines(childNodes: NodeListOf<ChildNode>) {
+      for (let i = 0; i < childNodes.length; i++) {
+          console.log(newValue);
+          const childNode = childNodes[i];
+
+          if (childNode.nodeName === 'BR') {
+              // BRs are always line breaks which means the next loop is on a fresh line
+              newValue += '\n';
+              isOnFreshLine = true;
+              continue;
+          }
+
+          // We may or may not need to create a new line
+          if (childNode.nodeName === 'DIV' && isOnFreshLine === false && i !== 0) {
+              // Divs create new lines for themselves if they aren't already on one
+              newValue += '\n';
+          }
+
+          // Whether we created a new line or not, we'll use it for this content so the next loop will not be on a fresh line:
+          isOnFreshLine = false;
+
+          // Add the text content if this is a text node:
+          if (childNode.nodeType === 3 && childNode.textContent && childNode.textContent.trim() !== '') {
+              newValue += childNode.textContent;
+          }
+
+          // If this node has children, get into them as well:
+          parseChildNodesForValueAndLines(childNode.childNodes);
+      }
+  }
+
+  parseChildNodesForValueAndLines(editableElement.childNodes);
+
+  return newValue;
+
+}

--- a/src/liveEditor/utils/getMultilinePlaintext.ts
+++ b/src/liveEditor/utils/getMultilinePlaintext.ts
@@ -6,7 +6,6 @@ export function getMultilinePlaintext(editableElement: Element): string {
   // Recursive function to navigate childNodes and build linebreaks with text
   function parseChildNodesForValueAndLines(childNodes: NodeListOf<ChildNode>) {
       for (let i = 0; i < childNodes.length; i++) {
-          console.log(newValue);
           const childNode = childNodes[i];
 
           if (childNode.nodeName === 'BR') {

--- a/src/liveEditor/utils/handleIndividualFields.ts
+++ b/src/liveEditor/utils/handleIndividualFields.ts
@@ -169,6 +169,9 @@ export async function handleIndividualFields(
                 visualEditorContainer.appendChild(pseudoEditableField);
                 actualEditableField = pseudoEditableField;
 
+                if(fieldType === FieldDataType.MULTILINE) 
+                    actualEditableField.addEventListener('paste', pasteAsPlainText);
+
                 // we will unobserve this in hideOverlay
                 elements.resizeObserver.observe(pseudoEditableField);
             } else if (elementComputedDisplay === "inline") {
@@ -257,6 +260,10 @@ export function cleanIndividualFieldResidual(elements: {
     );
     if (pseudoEditableElement) {
         elements.resizeObserver.unobserve(pseudoEditableElement);
+        pseudoEditableElement.removeEventListener(
+            "paste",
+            pasteAsPlainText
+        );
         pseudoEditableElement.remove();
         if (previousSelectedEditableDOM) {
             (previousSelectedEditableDOM as HTMLElement).style.removeProperty(


### PR DESCRIPTION
Ref: [VE-2556](https://contentstack.atlassian.net/browse/VE-2556)

Only change required on the CSR side is this CSS (on the multiline element): 
```css
white-space: pre-line
```

`dangerouslySetHTML` not required

[VE-2556]: https://contentstack.atlassian.net/browse/VE-2556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Also Important:
- **Old state:** Bolds, italics or html allowed on multiline components and even get saved to CMS.
- **New state:** Bolds, italics or html show up just while editing contenteditable, **and change to plaintext as soon as user unfocusses**, only plaintext with newlines gets saved to CMS.

> Will have to take a separate ticket to block showing html styles while editing `contenteditable`.