### PR TITLE
fix: hide contenteditable outline

### DIFF
--- a/src/liveEditor/components/visualEditor.tsx
+++ b/src/liveEditor/components/visualEditor.tsx
@@ -1,7 +1,9 @@
 import classNames from "classnames";
 import { hideOverlay } from "../generators/generateOverlay";
-import { liveEditorStyles } from "../liveEditor.style";
-import { glob } from "goober";
+import {
+    liveEditorStyles,
+    VisualBuilderGlobalStyles,
+} from "../liveEditor.style";
 
 interface VisualEditorProps {
     visualEditorContainer: HTMLDivElement | null;
@@ -11,6 +13,13 @@ interface VisualEditorProps {
 function VisualEditorComponent(props: VisualEditorProps): JSX.Element {
     return (
         <>
+            {/* For some reason, goober's glob and createGlobalStyle were not working in this case. */}
+            {/* glob also does not work when called in liveEditor's constructor */}
+            <style
+                dangerouslySetInnerHTML={{
+                    __html: VisualBuilderGlobalStyles,
+                }}
+            />
             <div
                 className={classNames(
                     liveEditorStyles()["visual-builder__cursor"],

--- a/src/liveEditor/index.ts
+++ b/src/liveEditor/index.ts
@@ -1,6 +1,5 @@
 import { Signal, signal } from "@preact/signals";
 
-import { generateStartEditingButton } from "./generators/generateStartEditingButton";
 import { inIframe } from "../common/inIframe";
 import Config from "../configManager/configManager";
 import {
@@ -12,31 +11,31 @@ import {
     ILivePreviewWindowType,
     IVisualEditorInitEvent,
 } from "../types/types";
+import { generateStartEditingButton } from "./generators/generateStartEditingButton";
 
 import { addFocusOverlay } from "./generators/generateOverlay";
 import { getEntryIdentifiersInCurrentPage } from "./utils/getEntryIdentifiersInCurrentPage";
 import liveEditorPostMessage from "./utils/liveEditorPostMessage";
 import { LiveEditorPostMessageEvents } from "./utils/types/postMessage.types";
 
+import { setup } from "goober";
+import { debounce, isEqual } from "lodash-es";
+import { h } from "preact";
+import { extractDetailsFromCslp } from "../cslp";
 import initUI from "./components";
-import { addEventListeners, removeEventListeners } from "./listeners";
+import { useDraftFieldsPostMessageEvent } from "./eventManager/useDraftFieldsPostMessageEvent";
+import { useHideFocusOverlayPostMessageEvent } from "./eventManager/useHideFocusOverlayPostMessageEvent";
+import { useScrollToField } from "./eventManager/useScrollToField";
+import { useVariantFieldsPostMessageEvent } from "./eventManager/useVariantsPostMessageEvent";
 import {
     generateEmptyBlocks,
     removeEmptyBlocks,
 } from "./generators/generateEmptyBlock";
-import { debounce, isEqual } from "lodash-es";
+import { addEventListeners, removeEventListeners } from "./listeners";
 import { addKeyboardShortcuts } from "./listeners/keyboardShortcuts";
-import { useHideFocusOverlayPostMessageEvent } from "./eventManager/useHideFocusOverlayPostMessageEvent";
-import { extractDetailsFromCslp } from "../cslp";
 import { FieldSchemaMap } from "./utils/fieldSchemaMap";
 import { isFieldDisabled } from "./utils/isFieldDisabled";
 import { updateFocussedState } from "./utils/updateFocussedState";
-import { useDraftFieldsPostMessageEvent } from "./eventManager/useDraftFieldsPostMessageEvent";
-import { h } from "preact";
-import { setup } from "goober";
-import { globalLiveEditorStyles } from "./liveEditor.style";
-import { useVariantFieldsPostMessageEvent } from "./eventManager/useVariantsPostMessageEvent";
-import { useScrollToField } from "./eventManager/useScrollToField";
 
 interface VisualEditorGlobalStateImpl {
     previousSelectedEditableDOM: HTMLElement | Element | null;
@@ -205,7 +204,6 @@ export class VisualEditor {
 
         // Initializing goober for css-in-js
         setup(h);
-        globalLiveEditorStyles();
 
         this.visualEditorContainer = document.querySelector(
             ".visual-builder__container"
@@ -255,7 +253,7 @@ export class VisualEditor {
                     focusedToolbar: this.focusedToolbar,
                     resizeObserver: this.resizeObserver,
                 });
-                useScrollToField()
+                useScrollToField();
 
                 this.mutationObserver.observe(document.body, {
                     childList: true,

--- a/src/liveEditor/liveEditor.style.ts
+++ b/src/liveEditor/liveEditor.style.ts
@@ -1,4 +1,4 @@
-import { css, glob } from "goober";
+import { css } from "goober";
 
 export function liveEditorStyles() {
     return {
@@ -28,7 +28,7 @@ export function liveEditorStyles() {
                 pointer-events: none !important;
                 position: fixed !important;
                 cursor: none;
-                z-index: 1000;
+                z-index: 9999;
             }
         `,
         "visual-builder__overlay__wrapper": css`
@@ -473,11 +473,9 @@ export function liveEditorStyles() {
     };
 }
 
-export function globalLiveEditorStyles() {
-    return glob`
+export const VisualBuilderGlobalStyles = `
        [data-cslp] [contenteditable="true"] {
             outline: none;
         }
 
-    `;
-}
+`;


### PR DESCRIPTION
Resolves [VE-3144](https://contentstack.atlassian.net/browse/VE-3144)

1. Hide contenteditable outline
2. Increase cursor z-index to 9999 (Academy team is using 1020 on their sidebar). We may need a better solution for this soon.

[VE-3144]: https://contentstack.atlassian.net/browse/VE-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ