### PR TITLE
fix: pressing space in button contenteditable

### DIFF
--- a/src/visualBuilder/listeners/index.ts
+++ b/src/visualBuilder/listeners/index.ts
@@ -6,6 +6,7 @@ import handleMouseHover, {
     hideHoverOutline,
     showCustomCursor,
 } from "./mouseHover";
+import { getCsDataOfElement } from "../utils/getCsDataOfElement";
 
 type AddEventListenersParams = Omit<
     EventListenerHandlerParams,
@@ -29,6 +30,45 @@ const eventHandlers = {
             resizeObserver: params.resizeObserver,
         });
     },
+    mousedown: (params: AddEventListenersParams) => (event: MouseEvent) => {
+        // NOTE: these exit conditions are same as the one in mouse click
+        // event above, if something changes there, the same must be done
+        // here
+        if (!params.overlayWrapper || !params.visualBuilderContainer) {
+            return;
+        }
+        const eventDetails = getCsDataOfElement(event);
+        if (!eventDetails) {
+            return;
+        }
+        const { editableElement } = eventDetails;
+
+        const previousSelectedElement =
+            VisualBuilder.VisualBuilderGlobalState.value
+                .previousSelectedEditableDOM;
+        if (
+            previousSelectedElement &&
+            previousSelectedElement === editableElement
+        ) {
+            return;
+        }
+        // if the selected element is our empty block element, return
+        if (
+            editableElement.classList.contains(
+                "visual-builder__empty-block-parent"
+            ) ||
+            editableElement.classList.contains("visual-builder__empty-block")
+        ) {
+            return;
+        }
+        // set contenteditable on button, so that it becomes editable without
+        // requiring a second click after the click event completed, else
+        // what happens is the button gets the focus on click and
+        // another click is required to enable content editing
+        if (editableElement.tagName === "BUTTON") {
+            editableElement.setAttribute("contenteditable", "true");
+        }
+    },
     mousemove: (params: AddEventListenersParams) => (event: MouseEvent) => {
         handleMouseHover({
             event: event,
@@ -51,14 +91,17 @@ export function addEventListeners(params: AddEventListenersParams): void {
     const mousemoveHandler = eventHandlers.mousemove(params);
     const mouseleaveHandler = eventHandlers.mouseleave(params);
     const mouseenterHandler = eventHandlers.mouseenter(params);
+    const mousedownHandler = eventHandlers.mousedown(params);
 
     eventListenersMap.set("click", clickHandler as EventListener);
     eventListenersMap.set("mousemove", mousemoveHandler as EventListener);
     eventListenersMap.set("mouseleave", mouseleaveHandler);
     eventListenersMap.set("mouseenter", mouseenterHandler);
+    eventListenersMap.set("mousedown", mousedownHandler as EventListener);
 
     window.addEventListener("click", clickHandler, { capture: true });
     window.addEventListener("mousemove", mousemoveHandler);
+    window.addEventListener("mousedown", mousedownHandler, { capture: true });
     document.documentElement.addEventListener("mouseleave", mouseleaveHandler);
     document.documentElement.addEventListener("mouseenter", mouseenterHandler);
 }
@@ -68,6 +111,7 @@ export function removeEventListeners(params: RemoveEventListenersParams): void {
     const mousemoveHandler = eventListenersMap.get("mousemove");
     const mouseleaveHandler = eventListenersMap.get("mouseleave");
     const mouseenterHandler = eventListenersMap.get("mouseenter");
+    const mousedownHandler = eventListenersMap.get("mousedown");
 
     if (clickHandler) {
         window.removeEventListener("click", clickHandler, { capture: true });
@@ -76,10 +120,19 @@ export function removeEventListeners(params: RemoveEventListenersParams): void {
         window.removeEventListener("mousemove", mousemoveHandler);
     }
     if (mouseleaveHandler) {
-        document.documentElement.removeEventListener("mouseleave", mouseleaveHandler);
+        document.documentElement.removeEventListener(
+            "mouseleave",
+            mouseleaveHandler
+        );
     }
     if (mouseenterHandler) {
-        document.documentElement.removeEventListener("mouseenter", mouseenterHandler);
+        document.documentElement.removeEventListener(
+            "mouseenter",
+            mouseenterHandler
+        );
+    }
+    if (mousedownHandler) {
+        window.removeEventListener("mousedown", mousedownHandler);
     }
 
     eventListenersMap.clear();

--- a/src/visualBuilder/utils/handleFieldMouseDown.ts
+++ b/src/visualBuilder/utils/handleFieldMouseDown.ts
@@ -7,6 +7,7 @@ import {
 } from "./constants";
 import { FieldDataType } from "./types/index.types";
 import { VisualBuilderPostMessageEvents } from "./types/postMessage.types";
+import { insertSpaceAtCursor } from "./insertSpaceAtCursor";
 
 export function handleFieldInput(e: Event): void {
     const event = e as InputEvent;
@@ -14,7 +15,10 @@ export function handleFieldInput(e: Event): void {
     const fieldType = targetElement.getAttribute(
         VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY
     ) as FieldDataType | null;
-    if (event.type === "input" && ALLOWED_INLINE_EDITABLE_FIELD.includes(fieldType as FieldDataType)) {
+    if (
+        event.type === "input" &&
+        ALLOWED_INLINE_EDITABLE_FIELD.includes(fieldType as FieldDataType)
+    ) {
         throttledFieldSync();
     }
 }
@@ -23,13 +27,13 @@ const throttledFieldSync = throttle(() => {
         const visualBuilderContainer = document.querySelector(
             ".visual-builder__container"
         ) as HTMLElement;
-        if(!visualBuilderContainer) return;
+        if (!visualBuilderContainer) return;
         sendFieldEvent({
             visualBuilderContainer,
             eventType: VisualBuilderPostMessageEvents.SYNC_FIELD,
-        })  
+        });
     } catch (error) {
-        console.error("Error in throttledFieldSync", error)
+        console.error("Error in throttledFieldSync", error);
     }
 }, 300);
 
@@ -40,10 +44,23 @@ export function handleFieldKeyDown(e: Event): void {
         VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY
     ) as FieldDataType | null;
 
+    if (targetElement.tagName === "BUTTON") {
+        handleKeyDownOnButton(event);
+    }
     if (fieldType === FieldDataType.NUMBER) {
         handleNumericFieldKeyDown(event);
     } else if (fieldType === FieldDataType.SINGLELINE) {
         handleSingleLineFieldKeyDown(event);
+    }
+}
+
+// spaces do not work inside a button content-editable
+// this adds a space and moves the cursor ahead, the
+// button press event is also prevented
+function handleKeyDownOnButton(e: KeyboardEvent) {
+    if (e.code === "Space" && e.target) {
+        e.preventDefault();
+        insertSpaceAtCursor(e.target as HTMLElement);
     }
 }
 

--- a/src/visualBuilder/utils/insertSpaceAtCursor.ts
+++ b/src/visualBuilder/utils/insertSpaceAtCursor.ts
@@ -1,0 +1,28 @@
+export function insertSpaceAtCursor(element: HTMLElement) {
+    // Check if the browser supports modern selection API
+    if (window.getSelection) {
+        const selection = window.getSelection();
+
+        // Ensure there's a valid selection
+        if (selection && selection.rangeCount > 0) {
+            const range = selection.getRangeAt(0);
+
+            // Create a text node with a space
+            const spaceNode = document.createTextNode("\u00A0");
+
+            // Delete any selected content first
+            range.deleteContents();
+
+            // Insert the space node
+            range.insertNode(spaceNode);
+
+            // Move cursor after the inserted space
+            range.setStartAfter(spaceNode);
+            range.setEndAfter(spaceNode);
+
+            // Update the selection
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
+    }
+}


### PR DESCRIPTION
This would earlier insert no space and instead send a click event on the button and a mouse-click event to the parent.