### PR TITLE
fix(VE-5061): add observer to observe cslp of selected element

### DIFF
--- a/src/visualBuilder/generators/generateOverlay.tsx
+++ b/src/visualBuilder/generators/generateOverlay.tsx
@@ -211,6 +211,13 @@ interface HideOverlayParams
 }
 
 export function hideOverlay(params: HideOverlayParams): void {
+    const focusElementObserver =
+        VisualBuilder.VisualBuilderGlobalState.value.focusElementObserver;
+    if (focusElementObserver) {
+        focusElementObserver.disconnect();
+        VisualBuilder.VisualBuilderGlobalState.value.focusElementObserver =
+            null;
+    }
     hideFocusOverlay({
         visualBuilderContainer: params.visualBuilderContainer,
         visualBuilderOverlayWrapper: params.visualBuilderOverlayWrapper,

--- a/src/visualBuilder/index.ts
+++ b/src/visualBuilder/index.ts
@@ -52,6 +52,7 @@ interface VisualBuilderGlobalStateImpl {
     audienceMode: boolean;
     locale: string;
     variant: string | null;
+    focusElementObserver: MutationObserver | null;
 }
 
 export class VisualBuilder {
@@ -69,6 +70,7 @@ export class VisualBuilder {
             audienceMode: false,
             locale: Config.get().stackDetails.masterLocale || "en-us",
             variant: null,
+            focusElementObserver: null,
         });
 
     private handlePositionChange(editableElement: HTMLElement) {
@@ -344,6 +346,7 @@ export class VisualBuilder {
             audienceMode: false,
             locale: "en-us",
             variant: null,
+            focusElementObserver: null,
         };
 
         // Remove DOM elements


### PR DESCRIPTION
Title: Added focus element observer to observe the focused element's data-cslp attribute and re-evaluate [handleBuilderInteraction](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) every time it changes.

Summary: This PR introduces a [MutationObserver](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to monitor changes to the data-cslp attribute of the focused element. When the data-cslp attribute changes, the [handleBuilderInteraction](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) function is re-evaluated to ensure the focussed Toolbar update

Changes:

Added a [MutationObserver](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to the [handleBuilderInteraction](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) function.
The observer watches for changes to the data-cslp attribute of the focused element.
When a change is detected, the observer disconnects itself and re-calls [handleBuilderInteraction](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) with the [reEvaluate](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) parameter set to true.
The observer is stored in the global state and properly disconnected when no longer needed.