### PR TITLE
fix: call onChangeCallback when live_preview parameter is present in URL

### DIFF
--- a/src/preview/contentstack-live-preview-HOC.ts
+++ b/src/preview/contentstack-live-preview-HOC.ts
@@ -152,7 +152,14 @@ class ContentstackLivePreview {
                 onChangeCallback;
         }
 
-        if (!skipInitialRender) {
+        const isWindowDefined = typeof window !== "undefined";
+        const isLivePreviewSearchParamPresent =
+            isWindowDefined &&
+            new URLSearchParams(window.location.search).has("live_preview");
+        // calling onChangeCallback when live_preview search parameter
+        // is present because we don't send the initial client-data-send
+        //  message in visual builder
+        if (!skipInitialRender || isLivePreviewSearchParamPresent) {
             onChangeCallback();
         }
 

--- a/src/preview/contentstack-live-preview-HOC.ts
+++ b/src/preview/contentstack-live-preview-HOC.ts
@@ -156,10 +156,15 @@ class ContentstackLivePreview {
         const isLivePreviewSearchParamPresent =
             isWindowDefined &&
             new URLSearchParams(window.location.search).has("live_preview");
+        const isBuilder =
+            isWindowDefined &&
+            new URLSearchParams(window.location.search).has("builder");
+        const shouldCallCallback =
+            isLivePreviewSearchParamPresent && isBuilder;
         // calling onChangeCallback when live_preview search parameter
         // is present because we don't send the initial client-data-send
         //  message in visual builder
-        if (!skipInitialRender || isLivePreviewSearchParamPresent) {
+        if (!skipInitialRender || shouldCallCallback) {
             onChangeCallback();
         }
 


### PR DESCRIPTION
- Visual Builder doesn't send client-data-send on site load, this leads to
the site not making any calls to the preview service which is required
for the subsequent entry PATCH requests to work correctly.
- `onChangeCallback` is called when either `skipInitialRender` is false or
when live_preview search parameter is present in the URL. 
- Since Visual Builder provides these values through the search parameter, the site makes entry GET calls to the preview service. Since live preview doesn't provide these params in non-SSR modes, it will continue to work the same.