### PR TITLE
feat: improve edit button rendering

### DIFF
--- a/src/livePreview/editButton/__test__/editButton.test.ts
+++ b/src/livePreview/editButton/__test__/editButton.test.ts
@@ -354,7 +354,7 @@ describe("shouldRenderEditButton", () => {
     });
 });
 
-describe.only("isPointerWithinEditButtonSafeZone", () => {
+describe("isPointerWithinEditButtonSafeZone", () => {
     let mockEvent: MouseEvent;
     let mockElement: HTMLElement;
 

--- a/src/livePreview/editButton/__test__/editButton.test.ts
+++ b/src/livePreview/editButton/__test__/editButton.test.ts
@@ -4,7 +4,8 @@ import {
     createMultipleEditButton,
     createSingularEditButton,
     getEditButtonPosition,
-    shouldRenderEditButton
+    isPointerWithinEditButtonSafeZone,
+    shouldRenderEditButton,
 } from "../editButton";
 import Config from "../../../configManager/configManager";
 import * as inIframe from "../../../common/inIframe";
@@ -248,11 +249,15 @@ describe("Edit button for Link", () => {
 
 describe("shouldRenderEditButton", () => {
     test("should return true if the config has enabled as true", () => {
-        vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true } });
+        vitest
+            .spyOn(Config, "get")
+            .mockReturnValue({ editButton: { enable: true } });
         expect(shouldRenderEditButton()).toBe(true);
     });
     test("should return false if the config has enabled as false", () => {
-        vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: false } });
+        vitest
+            .spyOn(Config, "get")
+            .mockReturnValue({ editButton: { enable: false } });
         expect(shouldRenderEditButton()).toBe(false);
     });
 
@@ -261,11 +266,15 @@ describe("shouldRenderEditButton", () => {
             const loggerSpy = vitest.spyOn(PublicLogger, "error");
             vitest.spyOn(Config, "get").mockReturnValue({ editButton: {} });
             expect(shouldRenderEditButton()).toBe(false);
-            expect(loggerSpy).toHaveBeenCalledWith("enable key is required inside editButton object");
+            expect(loggerSpy).toHaveBeenCalledWith(
+                "enable key is required inside editButton object"
+            );
         });
 
         test("should return true if cslp-buttons query parameter is true", () => {
-            vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true } });
+            vitest
+                .spyOn(Config, "get")
+                .mockReturnValue({ editButton: { enable: true } });
             vitest.spyOn(window, "location", "get").mockReturnValue({
                 href: "http://example.com?cslp-buttons=true",
             } as Location);
@@ -273,7 +282,9 @@ describe("shouldRenderEditButton", () => {
         });
 
         test("should return false if cslp-buttons query parameter is false", () => {
-            vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true } });
+            vitest
+                .spyOn(Config, "get")
+                .mockReturnValue({ editButton: { enable: true } });
             vitest.spyOn(window, "location", "get").mockReturnValue({
                 href: "http://example.com?cslp-buttons=false",
             } as Location);
@@ -281,39 +292,240 @@ describe("shouldRenderEditButton", () => {
         });
 
         test("should return true if cslp-buttons query parameter is not present", () => {
-            vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true } });
+            vitest
+                .spyOn(Config, "get")
+                .mockReturnValue({ editButton: { enable: true } });
             vitest.spyOn(window, "location", "get").mockReturnValue({
                 href: "http://example.com",
             } as Location);
             expect(shouldRenderEditButton()).toBe(true);
         });
-    })
+    });
     describe("exclude", () => {
         test("should return false if the config has exclude as `insideLivePreviewPortal` and the element is inside live preview portal", () => {
             vitest.spyOn(inIframe, "inIframe").mockReturnValue(true);
-            vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true, exclude: ["insideLivePreviewPortal"] } });
+            vitest.spyOn(Config, "get").mockReturnValue({
+                editButton: {
+                    enable: true,
+                    exclude: ["insideLivePreviewPortal"],
+                },
+            });
             expect(shouldRenderEditButton()).toBe(false);
         });
         test("should return true if the config has exclude as `insideLivePreviewPortal` and the element is not inside live preview portal", () => {
             vitest.spyOn(inIframe, "inIframe").mockReturnValue(false);
-            vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true, exclude: ["insideLivePreviewPortal"] } });
+            vitest.spyOn(Config, "get").mockReturnValue({
+                editButton: {
+                    enable: true,
+                    exclude: ["insideLivePreviewPortal"],
+                },
+            });
             expect(shouldRenderEditButton()).toBe(true);
         });
         test("should return false if the config has exclude as `outsideLivePreviewPortal` and the element is not inside live preview portal", () => {
             vitest.spyOn(inIframe, "inIframe").mockReturnValue(false);
-            vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true, exclude: ["outsideLivePreviewPortal"] } });
+            vitest.spyOn(Config, "get").mockReturnValue({
+                editButton: {
+                    enable: true,
+                    exclude: ["outsideLivePreviewPortal"],
+                },
+            });
             expect(shouldRenderEditButton()).toBe(false);
         });
         test("should return true if the config has exclude as `outsideLivePreviewPortal` and the element is inside live preview portal", () => {
             vitest.spyOn(inIframe, "inIframe").mockReturnValue(true);
-            vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true, exclude: ["outsideLivePreviewPortal"] } });
+            vitest.spyOn(Config, "get").mockReturnValue({
+                editButton: {
+                    enable: true,
+                    exclude: ["outsideLivePreviewPortal"],
+                },
+            });
             expect(shouldRenderEditButton()).toBe(true);
         });
-    })
+    });
 
     test("should return false if the website is rendered in Builder", () => {
-        vitest.spyOn(Config, "get").mockReturnValue({ editButton: { enable: true }, windowType: "builder" });
+        vitest.spyOn(Config, "get").mockReturnValue({
+            editButton: { enable: true },
+            windowType: "builder",
+        });
         vitest.spyOn(inIframe, "inIframe").mockReturnValue(true);
         expect(shouldRenderEditButton()).toBe(false);
-    })
-})
+    });
+});
+
+describe.only("isPointerWithinEditButtonSafeZone", () => {
+    let mockEvent: MouseEvent;
+    let mockElement: HTMLElement;
+
+    beforeEach(() => {
+        // Set up mock element that will be found in the composed path
+        mockElement = document.createElement("div");
+        mockElement.setAttribute("data-cslp", "");
+
+        // Mock getBoundingClientRect for the element
+        mockElement.getBoundingClientRect = vi.fn().mockReturnValue({
+            x: 100,
+            y: 100,
+            width: 200,
+            height: 150,
+            top: 100,
+            right: 300,
+            bottom: 250,
+            left: 100,
+        });
+
+        // Set up mock event
+        mockEvent = {
+            clientX: 150,
+            clientY: 120,
+            composedPath: vi.fn().mockReturnValue([mockElement, document.body]),
+        } as unknown as MouseEvent;
+    });
+
+    test("should return undefined when editButtonDomRect is not provided", () => {
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect: undefined,
+            editButtonPos: "top",
+        });
+        expect(result).toBeUndefined();
+    });
+
+    test("should return undefined when editButtonPos is not provided", () => {
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect: new DOMRect(150, 80, 50, 20),
+            editButtonPos: undefined,
+        });
+        expect(result).toBeUndefined();
+    });
+
+    test("should return undefined when editButtonDomRect has non-positive coordinates", () => {
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect: new DOMRect(-1, 80, 50, 20),
+            editButtonPos: "top",
+        });
+        expect(result).toBeUndefined();
+    });
+
+    test("should return undefined when no element with data-cslp attribute is found", () => {
+        mockEvent.composedPath = vi.fn().mockReturnValue([document.body]);
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect: new DOMRect(150, 80, 50, 20),
+            editButtonPos: "top",
+        });
+        expect(result).toBeUndefined();
+    });
+
+    test("should return false when pointer is within safe zone (top position)", () => {
+        // Button at the top with pointer near it
+        const editButtonDomRect = new DOMRect(150, 80, 50, 20);
+        // @ts-expect-error mocking event properties
+        mockEvent.clientX = 160;
+        // @ts-expect-error mocking event properties
+        mockEvent.clientY = 105;
+
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect,
+            editButtonPos: "top",
+        });
+        expect(result).toBe(false);
+    });
+
+    test("should return false when pointer is within safe zone (bottom position)", () => {
+        // Button at the bottom with pointer near it
+        const editButtonDomRect = new DOMRect(150, 260, 50, 20);
+        // @ts-expect-error mocking event properties
+        mockEvent.clientX = 160;
+        // @ts-expect-error mocking event properties
+        mockEvent.clientY = 255;
+
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect,
+            editButtonPos: "bottom",
+        });
+        expect(result).toBe(false);
+    });
+
+    test("should return false when pointer is within safe zone (left position)", () => {
+        // Button at the left with pointer near it
+        const editButtonDomRect = new DOMRect(80, 150, 20, 50);
+        // @ts-expect-error mocking event properties
+        mockEvent.clientX = 105;
+        // @ts-expect-error mocking event properties
+        mockEvent.clientY = 160;
+
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect,
+            editButtonPos: "left",
+        });
+        expect(result).toBe(false);
+    });
+
+    test("should return false when pointer is within safe zone (right position)", () => {
+        // Button at the right with pointer near it
+        const editButtonDomRect = new DOMRect(310, 150, 20, 50);
+        // @ts-expect-error mocking event properties
+        mockEvent.clientX = 305;
+        // @ts-expect-error mocking event properties
+        mockEvent.clientY = 160;
+
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect,
+            editButtonPos: "right",
+        });
+        expect(result).toBe(false);
+    });
+
+    test("should return true when pointer is outside safe zone", () => {
+        // Button at the top with pointer far away from it
+        const editButtonDomRect = new DOMRect(150, 80, 50, 20);
+        // @ts-expect-error mocking event properties
+        mockEvent.clientX = 160;
+        // @ts-expect-error mocking event properties
+        mockEvent.clientY = 200;
+
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect,
+            editButtonPos: "top",
+        });
+        expect(result).toBe(true);
+    });
+
+    test("should cap safe zone distance at MAX_SAFE_ZONE_DISTANCE", () => {
+        // Create a very large element that would exceed MAX_SAFE_ZONE_DISTANCE
+        mockElement.getBoundingClientRect = vi.fn().mockReturnValue({
+            x: 100,
+            y: 100,
+            width: 1000, // Large width
+            height: 1000, // Large height
+            top: 100,
+            right: 1100,
+            bottom: 1100,
+            left: 100,
+        });
+
+        const editButtonDomRect = new DOMRect(150, 80, 50, 20);
+        // @ts-expect-error mocking event properties
+        mockEvent.clientX = 160;
+        // @ts-expect-error mocking event properties
+        mockEvent.clientY = 115; // 35px from the bottom of the button which is > 30px
+
+        const result = isPointerWithinEditButtonSafeZone({
+            event: mockEvent,
+            editButtonDomRect,
+            editButtonPos: "top",
+        });
+
+        // Should still return false as we're within the max safe zone distance
+        expect(result).toBe(false);
+    });
+});

--- a/src/visualBuilder/listeners/mouseClick.ts
+++ b/src/visualBuilder/listeners/mouseClick.ts
@@ -73,7 +73,7 @@ async function handleBuilderInteraction(
 
     // if the target element is a studio-ui element, return
     // this is currently used for the "Edit in Studio" button
-    if (eventTarget?.dataset["studio-ui"] === "true") {
+    if (eventTarget?.getAttribute("data-studio-ui") === "true") {
         return;
     }
     // prevent default behavior for anchor elements and elements with cslp attribute


### PR DESCRIPTION
Use a safezone based on the edit button positioning to decide whether the edit tag should be moved to a differnt element or not.

![image](https://github.com/user-attachments/assets/b5702c34-02cf-420b-9429-428029954ef3)
