### PR TITLE
fix(VE-5561): change url to have query param in start edit button 

### DIFF
--- a/src/visualBuilder/utils/getVisualBuilderRedirectionUrl.ts
+++ b/src/visualBuilder/utils/getVisualBuilderRedirectionUrl.ts
@@ -34,6 +34,8 @@ export default function getVisualBuilderRedirectionUrl(): URL {
         searchParams.set("locale", locale);
     }
 
+    searchParams.set("from", "start-editing-button")
+
     const completeURL = new URL(
         `/#!/stack/${apiKey}/visual-builder?${searchParams.toString()}`,
         appUrl


### PR DESCRIPTION
added query param `from` which indicates that navigation is happening
from start edit button