### PR TITLE
VE-5544: Investigate button click issue with `data-cslp` attribute

### DIFF
--- a/src/visualBuilder/listeners/mouseClick.ts
+++ b/src/visualBuilder/listeners/mouseClick.ts
@@ -78,6 +78,14 @@ async function handleBuilderInteraction(
     if (eventTarget?.getAttribute("data-studio-ui") === "true") {
         return;
     }
+
+    if (params.event.altKey) {
+        if (isAnchorElement) {
+            params.event.preventDefault();
+            params.event.stopPropagation();
+        }
+        return;
+    }
     // prevent default behavior for anchor elements and elements with cslp attribute
     if (
         isAnchorElement ||


### PR DESCRIPTION
when user clicks on an interactive element of the app in iframe with while holding the modifier key (in our case it is alt for windows, linux and option for macos) the clicks behaviour is not altered, which means interactive elements will be interactive while holding modifier key and clicking the element