### PR TITLE
fix: enhance loading state for form field focus

### DIFF
--- a/src/visualBuilder/visualBuilder.style.ts
+++ b/src/visualBuilder/visualBuilder.style.ts
@@ -355,6 +355,7 @@ export function visualBuilderStyles() {
             }
         `,
         "visual-builder__button--comment-loader": css`
+            cursor: wait !important;
             svg.loader {
                 height: 16px;
                 width: 16px;


### PR DESCRIPTION

This pull request includes several changes to the `FieldToolbarComponent` in `src/visualBuilder/components/FieldToolbar.tsx` to improve the user experience by adding a loading state and simplifying the focus handling logic. Additionally, it includes a minor style update in `visualBuilder.style.ts`.

### Improvements to `FieldToolbarComponent`:

* [`src/visualBuilder/components/FieldToolbar.tsx`](diffhunk://#diff-f6c42a815d3fabd6edadc896c760b89af1436ea73a81e7caeea252b1f107e32cR42): Added an import for `LoadingIcon` to use in the loading state.
* [`src/visualBuilder/components/FieldToolbar.tsx`](diffhunk://#diff-f6c42a815d3fabd6edadc896c760b89af1436ea73a81e7caeea252b1f107e32cL96-R112): Simplified the `handleFormFieldFocus` function by removing unnecessary parameters and returning the promise directly.
* [`src/visualBuilder/components/FieldToolbar.tsx`](diffhunk://#diff-f6c42a815d3fabd6edadc896c760b89af1436ea73a81e7caeea252b1f107e32cR251-R271): Updated the `FieldToolbarComponent` to manage a loading state with `useState`, which disables the button and shows a loading icon while the form is loading.

### Style update:

* [`src/visualBuilder/visualBuilder.style.ts`](diffhunk://#diff-61d383bcb059d4f6135d7921c04ba5314a83d143d20766e094aa5b70a2c83055R358): Added a `cursor: wait` style to the `visual-builder__button--comment-loader` class to indicate the loading state.