### PR TITLE
feat(VE-5851): disable fields of update restricted entries

### DIFF
--- a/src/visualBuilder/components/FieldRevert/FieldRevertComponent.tsx
+++ b/src/visualBuilder/components/FieldRevert/FieldRevertComponent.tsx
@@ -195,6 +195,7 @@ export const VariantRevertDropdown = (props: any) => {
         invertTooltipPosition,
         toggleVariantDropdown,
         variantStatus = BASE_VARIANT_STATUS,
+        disabled,
     } = props;
     const dropdownRef = useRef<HTMLDivElement>(null);
     useHandleOutsideClick(dropdownRef, closeDropdown);
@@ -221,6 +222,7 @@ export const VariantRevertDropdown = (props: any) => {
                 style={{ padding: "6px" }}
                 data-tooltip={"Variant"}
                 data-testid={`visual-builder-canvas-variant-icon`}
+                disabled={disabled}
             >
                 <VariantIcon />
             </button>
@@ -236,6 +238,7 @@ export const VariantRevertDropdown = (props: any) => {
                 data-tooltip={"Variant Revert"}
                 data-testid={`visual-builder-canvas-variant-revert`}
                 onClick={toggleVariantDropdown}
+                disabled={disabled}
             >
                 <VariantIcon />
                 <CaretIcon open={props.isOpen} />

--- a/src/visualBuilder/components/FieldToolbar.tsx
+++ b/src/visualBuilder/components/FieldToolbar.tsx
@@ -398,6 +398,7 @@ function FieldToolbarComponent(
                                 closeDropdown={closeVariantDropdown}
                                 invertTooltipPosition={invertTooltipPosition}
                                 toggleVariantDropdown={toggleVariantDropdown}
+                                disabled={disableFieldActions}
                             />
                         ) : null}
                         {isMultiple && !isWholeMultipleField ? (

--- a/src/visualBuilder/components/FieldToolbar.tsx
+++ b/src/visualBuilder/components/FieldToolbar.tsx
@@ -314,6 +314,7 @@ function FieldToolbarComponent(
         </button>
     );
 
+    // TODO sibling count is incorrect for this purpose
     const totalElementCount = targetElement?.parentNode?.childElementCount ?? 1;
     const indexOfElement = fieldMetadata?.multipleFieldMetadata?.index;
 

--- a/src/visualBuilder/components/__test__/variantRevertDropdown.test.tsx
+++ b/src/visualBuilder/components/__test__/variantRevertDropdown.test.tsx
@@ -5,6 +5,7 @@ import {
     VariantRevertDropdown,
 } from "../FieldRevert/FieldRevertComponent";
 import { describe, it, expect, vi } from "vitest";
+import React from "preact/compat";
 
 const sendMock = vi.hoisted(() =>
     vi.fn().mockImplementation((_eventName: string) => {
@@ -83,6 +84,30 @@ describe("VariantRevertDropdown", () => {
             "visual-builder-canvas-variant-revert"
         );
         expect(button).toBeInTheDocument();
+    });
+
+    it("should disable dropdown button", async () => {
+        const { findByTestId } = await asyncRender(
+            <VariantRevertDropdown
+                closeDropdown={vi.fn()}
+                invertTooltipPosition={false}
+                toggleVariantDropdown={vi.fn()}
+                variantStatus={{
+                    isAddedInstances: true,
+                    isBaseModified: false,
+                    isDeletedInstances: true,
+                    isOrderChanged: false,
+                    fieldLevelCustomizations: true,
+                }}
+                fieldDataName="fieldDataName"
+                disabled={true}
+            />
+        );
+
+        const button = await findByTestId(
+            "visual-builder-canvas-variant-revert"
+        );
+        expect(button).toBeDisabled();
     });
 
     it("should call toggleVariantDropdown when button is clicked", async () => {

--- a/src/visualBuilder/components/fieldLabelWrapper.tsx
+++ b/src/visualBuilder/components/fieldLabelWrapper.tsx
@@ -14,6 +14,7 @@ import { visualBuilderStyles } from "../visualBuilder.style";
 import { CslpError } from "./CslpError";
 import { hasPostMessageError } from "../utils/errorHandling";
 import { VisualBuilderPostMessageEvents } from "../utils/types/postMessage.types";
+import { getEntryPermissionsCached } from "../utils/getEntryPermissionsCached";
 
 async function getFieldDisplayNames(fieldMetadata: CslpData[]) {
     const result = await visualBuilderPostMessage?.send<{
@@ -86,9 +87,15 @@ function FieldLabelWrapperComponent(
                 return;
             }
 
+            const entryPermissions = await getEntryPermissionsCached({
+                entryUid: props.fieldMetadata.entry_uid,
+                contentTypeUid: props.fieldMetadata.content_type_uid,
+                locale: props.fieldMetadata.locale,
+            });
             const { isDisabled: fieldDisabled, reason } = isFieldDisabled(
                 fieldSchema,
-                eventDetails
+                eventDetails,
+                entryPermissions
             );
 
             const currentFieldDisplayName =

--- a/src/visualBuilder/generators/__test__/appendFieldToolbar.test.ts
+++ b/src/visualBuilder/generators/__test__/appendFieldToolbar.test.ts
@@ -1,0 +1,119 @@
+import { appendFieldToolbar } from "../generateToolbar";
+import { getEntryPermissionsCached } from "../../utils/getEntryPermissionsCached";
+import { EntryPermissions } from "../../utils/getEntryPermissions";
+import { VisualBuilderCslpEventDetails } from "../../types/visualBuilder.types";
+import { CslpData } from "../../../cslp/types/cslp.types";
+import { render as renderOriginal } from "preact";
+
+vi.mock("preact", () => ({
+    render: vi.fn(),
+}));
+const render = vi.mocked(renderOriginal);
+
+/**
+ * Tests `appendFieldToolbar` in generateToolbar.ts
+ */
+describe("appendFieldToolbar", () => {
+    let mockEventDetails: VisualBuilderCslpEventDetails;
+    let focusedToolbar: HTMLDivElement;
+    let hideOverlay: () => void;
+
+    beforeEach(() => {
+        mockEventDetails = {
+            editableElement: document.createElement("div"),
+            cslpData: "test.cslp",
+            fieldMetadata: {
+                entry_uid: "test-entry",
+                content_type_uid: "test-content-type",
+                cslpValue: "test.cslp",
+                locale: "en-us",
+                fieldPath: "test-field",
+                fieldPathWithIndex: "test-field[0]",
+                multipleFieldMetadata: {
+                    index: 0,
+                    parentDetails: {
+                        parentPath: "",
+                        parentCslpValue: "",
+                    },
+                },
+                instance: {
+                    fieldPathWithIndex: "test-field[0]",
+                },
+                variant: "default",
+            } as CslpData,
+        };
+
+        focusedToolbar = document.createElement("div");
+        focusedToolbar.classList.add("visual-builder__focused-toolbar");
+        document.body.appendChild(focusedToolbar);
+
+        hideOverlay = vi.fn();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+        vi.clearAllMocks();
+    });
+
+    test("should not render toolbar if it already exists", async () => {
+        const existingToolbar = document.createElement("div");
+        existingToolbar.classList.add(
+            "visual-builder__focused-toolbar__multiple-field-toolbar"
+        );
+        focusedToolbar.appendChild(existingToolbar);
+
+        await appendFieldToolbar(mockEventDetails, focusedToolbar, hideOverlay);
+
+        expect(render).not.toHaveBeenCalled();
+    });
+
+    test("should render FieldToolbarComponent with correct props", async () => {
+        await appendFieldToolbar(mockEventDetails, focusedToolbar, hideOverlay);
+
+        expect(render).toHaveBeenCalledWith(
+            expect.any(Object),
+            expect.any(DocumentFragment)
+        );
+
+        const renderCall = (render as any).mock.calls[0][0];
+        expect(renderCall.props.eventDetails).toEqual(mockEventDetails);
+        expect(renderCall.props.hideOverlay).toBe(hideOverlay);
+        expect(renderCall.props.isVariant).toBe(false);
+    });
+
+    test("should render FieldToolbarComponent with variant prop", async () => {
+        await appendFieldToolbar(
+            mockEventDetails,
+            focusedToolbar,
+            hideOverlay,
+            true
+        );
+
+        const renderCall = (render as any).mock.calls[0][0];
+        expect(renderCall.props.isVariant).toBe(true);
+    });
+
+    test("should append rendered component to focusedToolbar", async () => {
+        const mockAppend = vi.spyOn(focusedToolbar, "append");
+        await appendFieldToolbar(mockEventDetails, focusedToolbar, hideOverlay);
+        expect(mockAppend).toHaveBeenCalledWith(expect.any(DocumentFragment));
+    });
+
+    test("should provide entry permissions to FieldToolbarComponent", async () => {
+        const mockEntryPermissions: EntryPermissions = {
+            create: true,
+            read: true,
+            update: true,
+            delete: true,
+            publish: true,
+        };
+        (getEntryPermissionsCached as any).mockResolvedValue(
+            mockEntryPermissions
+        );
+
+        await appendFieldToolbar(mockEventDetails, focusedToolbar, hideOverlay);
+
+        const renderCall = (render as any).mock.calls[0][0];
+        expect(renderCall.props.entryPermissions).toEqual(mockEntryPermissions);
+    });
+});

--- a/src/visualBuilder/generators/__test__/generateToolbar.test.tsx
+++ b/src/visualBuilder/generators/__test__/generateToolbar.test.tsx
@@ -39,23 +39,23 @@ describe("generateToolbar", () => {
     });
 
     describe("appendFieldToolbar", () => {
-        it("should render FieldToolbarComponent if not already present", () => {
-            appendFieldToolbar(eventDetails, focusedToolbarElement, hideOverlay);
+        it("should render FieldToolbarComponent if not already present", async () => {
+            await appendFieldToolbar(eventDetails, focusedToolbarElement, hideOverlay);
 
             expect(render).toBeCalled();
         });
 
-        it("should not render FieldToolbarComponent if already present", () => {
+        it("should not render FieldToolbarComponent if already present", async () => {
             focusedToolbarElement.innerHTML =
                 '<div class="visual-builder__focused-toolbar__multiple-field-toolbar"></div>';
 
-            appendFieldToolbar(eventDetails, focusedToolbarElement, hideOverlay);
+            await appendFieldToolbar(eventDetails, focusedToolbarElement, hideOverlay);
 
             expect(render).not.toHaveBeenCalled();
         });
 
-        it("should append the rendered component to the focusedToolbarElement", () => {
-            appendFieldToolbar(eventDetails, focusedToolbarElement, hideOverlay);
+        it("should append the rendered component to the focusedToolbarElement", async () => {
+            await appendFieldToolbar(eventDetails, focusedToolbarElement, hideOverlay);
 
             expect(spyAppend).toHaveBeenCalledWith(expect.any(DocumentFragment));
         });

--- a/src/visualBuilder/generators/generateToolbar.tsx
+++ b/src/visualBuilder/generators/generateToolbar.tsx
@@ -1,3 +1,4 @@
+import React from "preact/compat";
 import { VisualBuilderCslpEventDetails } from "../types/visualBuilder.types";
 import {
     DATA_CSLP_ATTR_SELECTOR,
@@ -12,6 +13,7 @@ import { isFieldDisabled } from "../utils/isFieldDisabled";
 import FieldToolbarComponent from "../components/FieldToolbar";
 import { render } from "preact";
 import FieldLabelWrapperComponent from "../components/fieldLabelWrapper";
+import { getEntryPermissionsCached } from "../utils/getEntryPermissionsCached";
 
 export function appendFocusedToolbar(
     eventDetails: VisualBuilderCslpEventDetails,
@@ -28,24 +30,30 @@ export function appendFocusedToolbar(
     );
 }
 
-export function appendFieldToolbar(
+export async function appendFieldToolbar(
     eventDetails: VisualBuilderCslpEventDetails,
     focusedToolbarElement: HTMLDivElement,
     hideOverlay: () => void,
     isVariant: boolean = false
-): void {
+): Promise<void> {
     if (
         focusedToolbarElement.querySelector(
             ".visual-builder__focused-toolbar__multiple-field-toolbar"
         )
     )
         return;
+    const entryPermissions = await getEntryPermissionsCached({
+        entryUid: eventDetails.fieldMetadata.entry_uid,
+        contentTypeUid: eventDetails.fieldMetadata.content_type_uid,
+        locale: eventDetails.fieldMetadata.locale,
+    });
     const wrapper = document.createDocumentFragment();
     render(
         <FieldToolbarComponent
             eventDetails={eventDetails}
             hideOverlay={hideOverlay}
             isVariant={isVariant}
+            entryPermissions={entryPermissions}
         />,
         wrapper
     );

--- a/src/visualBuilder/listeners/mouseClick.ts
+++ b/src/visualBuilder/listeners/mouseClick.ts
@@ -29,6 +29,7 @@ import { generateThread } from "../generators/generateThread";
 import { isCollabThread } from "../generators/generateThread";
 import { toggleCollabPopup } from "../generators/generateThread";
 import { fixSvgXPath } from "../utils/collabUtils";
+import { getEntryPermissionsCached } from "../utils/getEntryPermissionsCached";
 
 type HandleBuilderInteractionParams = Omit<
     EventListenerHandlerParams,
@@ -279,14 +280,23 @@ async function handleFieldSchemaAndIndividualFields(
     editableElement: Element,
     previousSelectedElement: Element | null
 ) {
-    const { content_type_uid, fieldPath } = fieldMetadata;
+    const { content_type_uid, entry_uid, fieldPath, locale } = fieldMetadata;
     const fieldSchema = await FieldSchemaMap.getFieldSchema(
         content_type_uid,
         fieldPath
     );
+    const entryAcl = await getEntryPermissionsCached({
+        entryUid: entry_uid,
+        contentTypeUid: content_type_uid,
+        locale,
+    });
 
     if (fieldSchema) {
-        const { isDisabled } = isFieldDisabled(fieldSchema, eventDetails);
+        const { isDisabled } = isFieldDisabled(
+            fieldSchema,
+            eventDetails,
+            entryAcl
+        );
         if (isDisabled) {
             addOverlay({
                 overlayWrapper: params.overlayWrapper,

--- a/src/visualBuilder/listeners/mouseHover.ts
+++ b/src/visualBuilder/listeners/mouseHover.ts
@@ -13,6 +13,7 @@ import { visualBuilderStyles } from "../visualBuilder.style";
 import { VB_EmptyBlockParentClass } from "../..";
 import Config from "../../configManager/configManager";
 import { isCollabThread } from "../generators/generateThread";
+import { getEntryPermissionsCached } from "../utils/getEntryPermissionsCached";
 
 const config = Config.get();
 export interface HandleMouseHoverParams
@@ -233,16 +234,24 @@ async function handleMouseHover(params: HandleMouseHoverParams): Promise<void> {
             FieldSchemaMap.getFieldSchema(content_type_uid, fieldPath).then(
                 (fieldSchema) => {
                     if (!fieldSchema) return;
-                    if (!params.customCursor) return;
-                    const { isDisabled: fieldDisabled } = isFieldDisabled(
-                        fieldSchema,
-                        eventDetails
-                    );
-                    const fieldType = getFieldType(fieldSchema);
-                    generateCustomCursor({
-                        fieldType,
-                        customCursor: params.customCursor,
-                        fieldDisabled,
+
+                    getEntryPermissionsCached({
+                        entryUid: fieldMetadata.entry_uid,
+                        contentTypeUid: fieldMetadata.content_type_uid,
+                        locale: fieldMetadata.locale,
+                    }).then((entryAcl) => {
+                        if (!params.customCursor) return;
+                        const { isDisabled: fieldDisabled } = isFieldDisabled(
+                            fieldSchema,
+                            eventDetails,
+                            entryAcl
+                        );
+                        const fieldType = getFieldType(fieldSchema);
+                        generateCustomCursor({
+                            fieldType,
+                            customCursor: params.customCursor,
+                            fieldDisabled,
+                        });
                     });
                 }
             );
@@ -259,9 +268,18 @@ async function handleMouseHover(params: HandleMouseHoverParams): Promise<void> {
             FieldSchemaMap.getFieldSchema(content_type_uid, fieldPath).then(
                 (fieldSchema) => {
                     if (!fieldSchema) return;
-                    const { isDisabled: fieldDisabled, reason } =
-                        isFieldDisabled(fieldSchema, eventDetails);
-                    addOutline(editableElement, fieldDisabled);
+                    getEntryPermissionsCached({
+                        entryUid: fieldMetadata.entry_uid,
+                        contentTypeUid: fieldMetadata.content_type_uid,
+                        locale: fieldMetadata.locale,
+                    }).then((entryAcl) => {
+                        const { isDisabled: fieldDisabled } = isFieldDisabled(
+                            fieldSchema,
+                            eventDetails,
+                            entryAcl
+                        );
+                        addOutline(editableElement, fieldDisabled);
+                    });
                 }
             );
         }

--- a/src/visualBuilder/utils/__test__/handleIndividualFields.test.ts
+++ b/src/visualBuilder/utils/__test__/handleIndividualFields.test.ts
@@ -71,7 +71,16 @@ describe("handleIndividualFields", () => {
         expect(FieldSchemaMap.getFieldSchema).toHaveBeenCalledWith("contentTypeUid", "fieldPath");
         expect(getFieldData).toHaveBeenCalledWith({ content_type_uid: "contentTypeUid", entry_uid: "entryUid", locale: "en-us" }, "fieldPathWithIndex");
         expect(getFieldType).toHaveBeenCalledWith(fieldSchema);
-        expect(isFieldDisabled).toHaveBeenCalledWith(fieldSchema, eventDetails);
+        expect(isFieldDisabled).toHaveBeenCalledWith(
+          fieldSchema, 
+          eventDetails, 
+          {
+            read: true,
+            update: true,
+            delete: true,
+            publish: true,
+          }
+        );
         expect(eventDetails.editableElement.getAttribute(VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY)).toBe(fieldType);
     });
 

--- a/src/visualBuilder/utils/__test__/isFieldDisabled.test.ts
+++ b/src/visualBuilder/utils/__test__/isFieldDisabled.test.ts
@@ -144,4 +144,88 @@ describe('isFieldDisabled', () => {
         expect(result.isDisabled).toBe(false);
         expect(result.reason).toBe('');
     });
+    
+    it('should return disabled state due to read-only role', () => {
+        const fieldSchemaMap: ISchemaFieldMap = {
+            data_type: "block",
+            display_name: "Test Block",
+            title: "Test Block",
+            uid: "test_block",
+            schema: [],
+            field_metadata: {
+                updateRestrict: true,
+            },
+        };
+        const eventFieldDetails: FieldDetails = {
+            editableElement: document.createElement("div"),
+            fieldMetadata: {
+                locale: "en-us",
+                entry_uid: "test_entry",
+                content_type_uid: "test_content_type",
+                cslpValue: "test_cslp",
+                variant: "default",
+                fieldPath: "test_field",
+                fieldPathWithIndex: "test_field[0]",
+                instance: {
+                    fieldPathWithIndex: "test_field[0]",
+                },
+                multipleFieldMetadata: {
+                    index: 0,
+                    parentDetails: {
+                        parentCslpValue: "",
+                        parentPath: "",
+                    },
+                },
+            },
+        };
+
+        const result = isFieldDisabled(fieldSchemaMap, eventFieldDetails);
+        expect(result.isDisabled).toBe(true);
+        expect(result.reason).toBe("You have only read access to this field");
+    });
+
+    it("should return disabled state due to entry update restriction", () => {
+        const fieldSchemaMap: ISchemaFieldMap = {
+            data_type: "block",
+            display_name: "Test Block",
+            title: "Test Block",
+            uid: "test_block",
+            schema: [],
+        };
+        const eventFieldDetails: FieldDetails = {
+            editableElement: document.createElement("div"),
+            fieldMetadata: {
+                locale: "en-us",
+                entry_uid: "test_entry",
+                content_type_uid: "test_content_type",
+                cslpValue: "test_cslp",
+                variant: "default",
+                fieldPath: "test_field",
+                fieldPathWithIndex: "test_field[0]",
+                instance: {
+                    fieldPathWithIndex: "test_field[0]",
+                },
+                multipleFieldMetadata: {
+                    index: 0,
+                    parentDetails: {
+                        parentCslpValue: "",
+                        parentPath: "",
+                    },
+                },
+            },
+        };
+
+        const result = isFieldDisabled(fieldSchemaMap, eventFieldDetails, {
+            update: false,
+            create: true,
+            read: true,
+            delete: true,
+            publish: true,
+        });
+        expect(result.isDisabled).toBe(true);
+        expect(result.reason).toBe(
+            "You do not have permission to edit this entry"
+        );
+    });
+
 });

--- a/src/visualBuilder/utils/__test__/updateFocussedState.test.ts
+++ b/src/visualBuilder/utils/__test__/updateFocussedState.test.ts
@@ -3,10 +3,26 @@ import { updateFocussedState, updateFocussedStateOnMutation } from "../updateFoc
 import { VisualBuilder } from "../..";
 import { addFocusOverlay, hideFocusOverlay } from "../../generators/generateOverlay";
 import { mockGetBoundingClientRect } from "../../../__test__/utils";
+import { act } from "@testing-library/preact";
+import { singleLineFieldSchema } from "../../../__test__/data/fields";
+
 vi.mock("../../generators/generateOverlay", () => ({
     addFocusOverlay: vi.fn(),
     hideFocusOverlay: vi.fn()
 }));
+
+vi.mock("../../utils/fieldSchemaMap", () => {
+    return {
+        FieldSchemaMap: {
+            getFieldSchema: vi
+                .fn()
+                .mockImplementation((_content_type_uid, _fieldPath) => {
+                    return singleLineFieldSchema;
+                }),
+        },
+    };
+});
+
 describe("updateFocussedState", () => {
     beforeEach(() => {
         let previousSelectedEditableDOM: HTMLElement;
@@ -22,8 +38,8 @@ describe("updateFocussedState", () => {
                     .previousSelectedEditableDOM = null;
         
     })
-    it("should return early if required elements are not provided", () => {
-        const result = updateFocussedState({
+    it("should return early if required elements are not provided", async () => {
+        const result = await updateFocussedState({
             editableElement: null,
             visualBuilderContainer: null,
             overlayWrapper: null,
@@ -55,7 +71,7 @@ describe("updateFocussedState", () => {
 
     });
 
-    it("should update pseudo editable element styles", () => {
+    it("should update pseudo editable element styles", async () => {
         const editableElementMock = document.createElement("div");
         editableElementMock.setAttribute("data-cslp", "content_type_uid.entry_uid.locale.field_path");
         const visualBuilderContainerMock = document.createElement("div");
@@ -67,18 +83,20 @@ describe("updateFocussedState", () => {
         pseudoEditableElementMock.classList.add("visual-builder__pseudo-editable-element");
         visualBuilderContainerMock.appendChild(pseudoEditableElementMock);
         
-        updateFocussedState({
-            editableElement: editableElementMock,
-            visualBuilderContainer: visualBuilderContainerMock,
-            overlayWrapper: overlayWrapperMock,
-            focusedToolbar: focusedToolbarMock,
-            resizeObserver: resizeObserverMock,
-        });
+        await act(async () => {
+          await updateFocussedState({
+              editableElement: editableElementMock,
+              visualBuilderContainer: visualBuilderContainerMock,
+              overlayWrapper: overlayWrapperMock,
+              focusedToolbar: focusedToolbarMock,
+              resizeObserver: resizeObserverMock,
+          });
+        })
 
         expect(pseudoEditableElementMock.style.visibility).toBe("visible");
     });
 
-    it("should update position of toolbar", () => {
+    it("should update position of toolbar", async () => {
         const editableElementMock = document.createElement("div");
         mockGetBoundingClientRect(editableElementMock)
         editableElementMock.setAttribute("data-cslp", "content_type_uid.entry_uid.locale.field_path");
@@ -93,7 +111,7 @@ describe("updateFocussedState", () => {
 
         document.querySelector = vi.fn().mockReturnValue(editableElementMock);
 
-        updateFocussedState({
+        await updateFocussedState({
             editableElement: editableElementMock,
             visualBuilderContainer: visualBuilderContainerMock,
             overlayWrapper: overlayWrapperMock,

--- a/src/visualBuilder/utils/__tests__/createCachedFetch.test.ts
+++ b/src/visualBuilder/utils/__tests__/createCachedFetch.test.ts
@@ -1,0 +1,171 @@
+import { createCachedFetch } from "../createCachedFetch";
+
+describe("createCachedFetch", () => {
+    // Helper to create a controlled promise
+    const createControlledPromise = <T>(_value?: T) => {
+        let resolve: (value: T) => void;
+        let reject: (reason: any) => void;
+        const promise = new Promise<T>((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return { promise, resolve: resolve!, reject: reject! };
+    };
+
+    it("should cache results for identical arguments", async () => {
+        const fetchFn = vi.fn().mockResolvedValue("cached result");
+        const cachedFn = createCachedFetch(fetchFn);
+
+        const result1 = await cachedFn("arg1", "arg2");
+        const result2 = await cachedFn("arg1", "arg2");
+
+        expect(result1).toBe("cached result");
+        expect(result2).toBe("cached result");
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(fetchFn).toHaveBeenCalledWith("arg1", "arg2");
+    });
+
+    it("should make separate calls for different arguments", async () => {
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValueOnce("result1")
+            .mockResolvedValueOnce("result2");
+        const cachedFn = createCachedFetch(fetchFn);
+
+        const result1 = await cachedFn("arg1");
+        const result2 = await cachedFn("arg2");
+
+        expect(result1).toBe("result1");
+        expect(result2).toBe("result2");
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle concurrent calls with the same arguments", async () => {
+        // Create a controlled promise to manually resolve the fetch
+        const { promise, resolve } = createControlledPromise<string>();
+        const fetchFn = vi.fn().mockReturnValue(promise);
+        const cachedFn = createCachedFetch(fetchFn);
+
+        // Start two concurrent requests
+        const request1 = cachedFn("concurrent");
+        const request2 = cachedFn("concurrent");
+
+        // The fetch function should only be called once
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+
+        // Resolve the underlying fetch
+        resolve("shared result");
+
+        // Both requests should resolve with the same result
+        const [result1, result2] = await Promise.all([request1, request2]);
+        expect(result1).toBe("shared result");
+        expect(result2).toBe("shared result");
+    });
+
+    it("should propagate errors and not cache failed results", async () => {
+        const error = new Error("fetch failed");
+        const fetchFn = vi
+            .fn()
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce("result after error");
+        const cachedFn = createCachedFetch(fetchFn);
+
+        // First call should reject
+        await expect(cachedFn("error-test")).rejects.toThrow("fetch failed");
+
+        // Second call should retry fetch and succeed
+        const result = await cachedFn("error-test");
+        expect(result).toBe("result after error");
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should use the custom UID resolver when provided", async () => {
+        const fetchFn = vi.fn().mockResolvedValue("custom uid result");
+        // Create custom resolver that only uses the first argument
+        const uidResolver = (arg1: string) => arg1;
+        const cachedFn = createCachedFetch(fetchFn, uidResolver);
+
+        await cachedFn("same", "different1");
+        await cachedFn("same", "different2");
+
+        // Should only call once since our UID resolver only cares about first arg
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should clear the cache when clearCache is called", async () => {
+        const fetchFn = vi
+            .fn()
+            .mockResolvedValueOnce("first call")
+            .mockResolvedValueOnce("after clear");
+        const cachedFn = createCachedFetch(fetchFn);
+
+        // Make initial call
+        const result1 = await cachedFn("clear-test");
+        expect(result1).toBe("first call");
+
+        // Clear the cache
+        cachedFn.clearCache();
+
+        // Make same call again - should fetch again
+        const result2 = await cachedFn("clear-test");
+        expect(result2).toBe("after clear");
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should clear pending promises when clearCache is called", async () => {
+        // Create a controlled promise
+        const { promise, resolve } = createControlledPromise<string>();
+        const fetchFn = vi.fn().mockReturnValue(promise);
+        const cachedFn = createCachedFetch(fetchFn);
+
+        // Start a request
+        const pendingRequest = cachedFn("pending");
+
+        // Clear cache while request is pending
+        cachedFn.clearCache();
+
+        // Setup new mock for next call
+        fetchFn.mockResolvedValueOnce("new result");
+
+        // New request should cause a new fetch
+        const newRequest = cachedFn("pending");
+
+        // Resolve the original promise
+        resolve("pending result");
+
+        // Check both results
+        const pendingResult = await pendingRequest;
+        const newResult = await newRequest;
+
+        expect(pendingResult).toBe("pending result");
+        expect(newResult).toBe("new result");
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle errors in concurrent requests", async () => {
+        // Create a controlled promise
+        const { promise, reject } = createControlledPromise<string>();
+        const fetchFn = vi.fn().mockReturnValue(promise);
+        const cachedFn = createCachedFetch(fetchFn);
+
+        // Start two concurrent requests
+        const request1 = cachedFn("error-concurrent");
+        const request2 = cachedFn("error-concurrent");
+
+        // Reject the promise
+        const error = new Error("concurrent error");
+        reject(error);
+
+        // Both requests should fail with the same error
+        await expect(request1).rejects.toThrow("concurrent error");
+        await expect(request2).rejects.toThrow("concurrent error");
+
+        // Setup next call to succeed
+        fetchFn.mockResolvedValueOnce("after error");
+
+        // Next call should retry
+        const result = await cachedFn("error-concurrent");
+        expect(result).toBe("after error");
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/visualBuilder/utils/createCachedFetch.ts
+++ b/src/visualBuilder/utils/createCachedFetch.ts
@@ -1,0 +1,65 @@
+/**
+ * Creates a cached async fetch function with support for any number of arguments
+ * @param fetchFn - The async function to cache
+ * @param uidResolver - Function that generates a unique ID from the arguments passed to fetchFn
+ * @returns A cached version of the fetch function with the same signature
+ */
+export function createCachedFetch<TArgs extends any[], TResult>(
+    fetchFn: (...args: TArgs) => Promise<TResult>,
+    uidResolver: (...args: TArgs) => string = (...args) => JSON.stringify(args)
+): {
+    (...args: TArgs): Promise<TResult>;
+    clearCache: () => void;
+} {
+    // Cache storage
+    const cache = new Map<string, TResult>();
+    // Track in-flight requests
+    const pendingPromises = new Map<string, Promise<TResult>>();
+
+    /**
+     * The cached fetch function
+     * @param args - Arguments to pass to the original fetch function
+     * @returns Promise that resolves with the data
+     */
+    async function cachedFetch(...args: TArgs): Promise<TResult> {
+        // Generate unique ID for these arguments
+        const uid = uidResolver(...args);
+
+        // Return cached value if available
+        if (cache.has(uid)) {
+            return cache.get(uid)!;
+        }
+
+        // Return existing promise if request is already in progress
+        if (pendingPromises.has(uid)) {
+            return pendingPromises.get(uid)!;
+        }
+
+        // Create new promise for this request
+        const promise = fetchFn(...args)
+            .then((data) => {
+                // Store result in cache
+                cache.set(uid, data);
+                // Remove from pending
+                pendingPromises.delete(uid);
+                return data;
+            })
+            .catch((error) => {
+                // Clean up on error
+                pendingPromises.delete(uid);
+                throw error;
+            });
+
+        // Store the promise
+        pendingPromises.set(uid, promise);
+        return promise;
+    }
+
+    // Add clearCache method to the function
+    cachedFetch.clearCache = () => {
+        cache.clear();
+        pendingPromises.clear();
+    };
+
+    return cachedFetch;
+}

--- a/src/visualBuilder/utils/getEntryPermissions.ts
+++ b/src/visualBuilder/utils/getEntryPermissions.ts
@@ -1,0 +1,41 @@
+import visualBuilderPostMessage from "./visualBuilderPostMessage";
+
+export interface EntryPermissions {
+    create: boolean;
+    read: boolean;
+    update: boolean;
+    delete: boolean;
+    publish: boolean;
+}
+
+export async function getEntryPermissions({
+    entryUid,
+    contentTypeUid,
+    locale,
+}: {
+    entryUid: string;
+    contentTypeUid: string;
+    locale: string;
+}) {
+    const permissions = await visualBuilderPostMessage?.send<EntryPermissions>(
+        "get-permissions",
+        {
+            type: "entry",
+            entryUid,
+            contentTypeUid,
+            locale,
+        }
+    );
+    // allow editing when things go wrong,
+    // e.g. when no permissions are received
+    if (!permissions) {
+        return {
+            create: true,
+            read: true,
+            update: true,
+            delete: true,
+            publish: true,
+        };
+    }
+    return permissions;
+}

--- a/src/visualBuilder/utils/getEntryPermissions.ts
+++ b/src/visualBuilder/utils/getEntryPermissions.ts
@@ -17,25 +17,30 @@ export async function getEntryPermissions({
     contentTypeUid: string;
     locale: string;
 }) {
-    const permissions = await visualBuilderPostMessage?.send<EntryPermissions>(
-        "get-permissions",
-        {
-            type: "entry",
-            entryUid,
-            contentTypeUid,
-            locale,
+    try {
+        const permissions =
+            await visualBuilderPostMessage?.send<EntryPermissions>(
+                "get-permissions",
+                {
+                    type: "entry",
+                    entryUid,
+                    contentTypeUid,
+                    locale,
+                }
+            );
+        if (permissions) {
+            return permissions;
         }
-    );
+    } catch (error) {
+        console.debug("[Visual Builder] Error fetching permissions", error);
+    }
     // allow editing when things go wrong,
     // e.g. when no permissions are received
-    if (!permissions) {
-        return {
-            create: true,
-            read: true,
-            update: true,
-            delete: true,
-            publish: true,
-        };
-    }
-    return permissions;
+    return {
+        create: true,
+        read: true,
+        update: true,
+        delete: true,
+        publish: true,
+    };
 }

--- a/src/visualBuilder/utils/getEntryPermissionsCached.ts
+++ b/src/visualBuilder/utils/getEntryPermissionsCached.ts
@@ -1,0 +1,9 @@
+import { getEntryPermissions } from "./getEntryPermissions";
+import { createCachedFetch } from "./createCachedFetch";
+
+console.log("Loading module: getEntryPermissionsCached [original]");
+export const getEntryPermissionsCached = createCachedFetch(
+    getEntryPermissions,
+    ({ entryUid, contentTypeUid, locale }) =>
+        `${entryUid}.${contentTypeUid}.${locale}`
+);

--- a/src/visualBuilder/utils/getEntryPermissionsCached.ts
+++ b/src/visualBuilder/utils/getEntryPermissionsCached.ts
@@ -1,7 +1,6 @@
 import { getEntryPermissions } from "./getEntryPermissions";
 import { createCachedFetch } from "./createCachedFetch";
 
-console.log("Loading module: getEntryPermissionsCached [original]");
 export const getEntryPermissionsCached = createCachedFetch(
     getEntryPermissions,
     ({ entryUid, contentTypeUid, locale }) =>

--- a/src/visualBuilder/utils/handleIndividualFields.ts
+++ b/src/visualBuilder/utils/handleIndividualFields.ts
@@ -16,6 +16,7 @@ import { isFieldMultiple } from "./isFieldMultiple";
 import { handleInlineEditableField } from "./handleInlineEditableField";
 import { VisualBuilderEditContext } from "./types/index.types";
 import { pasteAsPlainText } from "./pasteAsPlainText";
+import { getEntryPermissionsCached } from "./getEntryPermissionsCached";
 
 /**
  * It handles all the fields based on their data type and its "multiple" property.
@@ -47,7 +48,16 @@ export async function handleIndividualFields(
 
     const fieldType = getFieldType(fieldSchema);
 
-    const { isDisabled: disabled } = isFieldDisabled(fieldSchema, eventDetails);
+    const entryAcl = await getEntryPermissionsCached({
+        entryUid: entry_uid,
+        contentTypeUid: content_type_uid,
+        locale,
+    });
+    const { isDisabled: disabled } = isFieldDisabled(
+        fieldSchema,
+        eventDetails,
+        entryAcl
+    );
 
     editableElement.setAttribute(
         VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY,

--- a/src/visualBuilder/utils/isFieldDisabled.ts
+++ b/src/visualBuilder/utils/isFieldDisabled.ts
@@ -3,6 +3,7 @@ import Config from "../../configManager/configManager";
 import { ISchemaFieldMap } from "./types/index.types";
 import { VisualBuilder } from "..";
 import { FieldDetails } from "../components/FieldToolbar";
+import { EntryPermissions } from "./getEntryPermissions";
 
 enum DisableReason {
     ReadOnly = "You have only read access to this field",
@@ -12,6 +13,7 @@ enum DisableReason {
     DisabledVariant = "This field is not editable as it doesn't match the selected variant",
     UnlocalizedVariant = "This field is not editable as it is not localized",
     None = "",
+    EntryUpdateRestricted = "You do not have permission to update this entry",
 }
 
 interface FieldDisableState {
@@ -20,6 +22,9 @@ interface FieldDisableState {
 }
 
 const getDisableReason = (flags: Record<string, boolean>): DisableReason => {
+    if (flags.updateRestrictDueToEntryUpdateRestriction) {
+        return DisableReason.EntryUpdateRestricted;
+    }
     if (flags.updateRestrictDueToRole) return DisableReason.ReadOnly;
     if (flags.updateRestrictDueToNonLocalizableFields)
         return DisableReason.LocalizedEntry;
@@ -36,14 +41,15 @@ const getDisableReason = (flags: Record<string, boolean>): DisableReason => {
 
 export const isFieldDisabled = (
     fieldSchemaMap: ISchemaFieldMap,
-    eventFieldDetails: FieldDetails
+    eventFieldDetails: FieldDetails,
+    entryPermissions?: EntryPermissions
 ): FieldDisableState => {
     const { editableElement, fieldMetadata } = eventFieldDetails;
     const masterLocale = Config.get().stackDetails.masterLocale || "en-us";
     const { locale: cmsLocale, variant } =
         VisualBuilder.VisualBuilderGlobalState.value;
 
-    const flags = {
+    const flags: Record<string, boolean> = {
         updateRestrictDueToRole: Boolean(
             fieldSchemaMap?.field_metadata?.updateRestrict
         ),
@@ -60,6 +66,10 @@ export const isFieldDisabled = (
         updateRestrictDueToAudienceMode: false,
         updateRestrictDueToDisabledVariant: false,
     };
+
+    if (entryPermissions && !entryPermissions.update) {
+        flags.updateRestrictDueToEntryUpdateRestriction = true;
+    }
 
     if (
         VisualBuilder.VisualBuilderGlobalState.value.audienceMode &&

--- a/src/visualBuilder/utils/isFieldDisabled.ts
+++ b/src/visualBuilder/utils/isFieldDisabled.ts
@@ -13,7 +13,7 @@ enum DisableReason {
     DisabledVariant = "This field is not editable as it doesn't match the selected variant",
     UnlocalizedVariant = "This field is not editable as it is not localized",
     None = "",
-    EntryUpdateRestricted = "You do not have permission to update this entry",
+    EntryUpdateRestricted = "You do not have permission to edit this entry",
 }
 
 interface FieldDisableState {

--- a/src/visualBuilder/utils/updateFocussedState.ts
+++ b/src/visualBuilder/utils/updateFocussedState.ts
@@ -6,15 +6,17 @@ import {
     hideFocusOverlay,
 } from "../generators/generateOverlay";
 import { hideHoverOutline } from "../listeners/mouseHover";
+import { getEntryPermissionsCached } from "./getEntryPermissionsCached";
 import {
     LIVE_PREVIEW_OUTLINE_WIDTH_IN_PX,
     RIGHT_EDGE_BUFFER,
     TOOLBAR_EDGE_BUFFER,
     TOP_EDGE_BUFFER,
 } from "./constants";
+import { FieldSchemaMap } from "./fieldSchemaMap";
 import getChildrenDirection from "./getChildrenDirection";
 import { getPsuedoEditableElementStyles } from "./getPsuedoEditableStylesElement";
-import getStyleOfAnElement from "./getStyleOfAnElement";
+import { isFieldDisabled } from "./isFieldDisabled";
 
 interface ToolbarPositionParams {
     focusedToolbar: HTMLElement | null;
@@ -80,7 +82,7 @@ function positionToolbar({
  * create new elements, it just updates the existing ones whenever possible.
  * NOTE: breakdown this function into multiple functions when the need arises
  */
-export function updateFocussedState({
+export async function updateFocussedState({
     editableElement,
     visualBuilderContainer,
     overlayWrapper,
@@ -92,7 +94,7 @@ export function updateFocussedState({
     overlayWrapper: HTMLDivElement | null;
     focusedToolbar: HTMLDivElement | null;
     resizeObserver: ResizeObserver | null;
-}): void {
+}): Promise<void> {
     let previousSelectedEditableDOM =
         VisualBuilder.VisualBuilderGlobalState.value
             .previousSelectedEditableDOM;
@@ -126,8 +128,28 @@ export function updateFocussedState({
             previousSelectedEditableDOM;
     }
 
+    const cslp = editableElement?.getAttribute("data-cslp") || "";
+    const fieldMetadata = extractDetailsFromCslp(cslp);
+
     hideHoverOutline(visualBuilderContainer);
-    addFocusOverlay(previousSelectedEditableDOM, overlayWrapper);
+
+    // in every case, this function will bring cached values
+    // and this should be quick
+    const fieldSchema = await FieldSchemaMap.getFieldSchema(
+        fieldMetadata.content_type_uid,
+        fieldMetadata.fieldPath
+    );
+    const entryAcl = await getEntryPermissionsCached({
+        entryUid: fieldMetadata.entry_uid,
+        contentTypeUid: fieldMetadata.content_type_uid,
+        locale: fieldMetadata.locale,
+    });
+    const { isDisabled } = isFieldDisabled(
+        fieldSchema,
+        { editableElement, fieldMetadata },
+        entryAcl
+    );
+    addFocusOverlay(previousSelectedEditableDOM, overlayWrapper, isDisabled);
 
     // update psuedo editable element if present
     const psuedoEditableElement = visualBuilderContainer.querySelector(
@@ -147,9 +169,6 @@ export function updateFocussedState({
         // when creating the pseudo editable element, so make the psuedo visible
         psuedoEditableElement.style.visibility = "visible";
     }
-
-    const cslp = editableElement?.getAttribute("data-cslp") || "";
-    const fieldMetadata = extractDetailsFromCslp(cslp);
 
     const targetElementDimension = editableElement.getBoundingClientRect();
     if (targetElementDimension.width && targetElementDimension.height) {

--- a/src/visualBuilder/visualBuilder.style.ts
+++ b/src/visualBuilder/visualBuilder.style.ts
@@ -320,6 +320,15 @@ export function visualBuilderStyles() {
                 border-color 0.15s ease-in-out,
                 box-shadow 0.15s ease-in-out;
             // vertical-align: middle;
+            &:disabled {
+                cursor: not-allowed;
+                svg {
+                    fill: #999;
+                    path {
+                        fill: #999;
+                    }
+                }
+            }
         `,
         "visual-builder__button--primary": css`
             background-color: #6c5ce7;
@@ -385,7 +394,7 @@ export function visualBuilderStyles() {
                 gap: 8px;
             }
 
-            .visual-builder__button:hover {
+            .visual-builder__button:enabled:hover {
                 background-color: #f5f5f5;
 
                 svg {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -18,7 +18,10 @@ beforeAll(() => {
     vi.mock("./src/visualBuilder/utils/getEntryPermissionsCached", () => {
         return {
             getEntryPermissionsCached: vi.fn().mockResolvedValue({
+                read: true,
+                publish: true,
                 update: true,
+                delete: true,
             }),
         };
     });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -13,8 +13,16 @@ beforeAll(() => {
         disconnect: vi.fn(),
     }));
 
-  document.elementFromPoint = vi.fn();
-})
+    document.elementFromPoint = vi.fn();
+
+    vi.mock("./src/visualBuilder/utils/getEntryPermissionsCached", () => {
+        return {
+            getEntryPermissionsCached: vi.fn().mockResolvedValue({
+                update: true,
+            }),
+        };
+    });
+});
 
 afterAll(() => {
     cleanup();


### PR DESCRIPTION
Use get-permissions to request entry permissions from parent and disable certain actions such as inline editing, instance actions.