### PR TITLE
fix(VE-6191): clear field schema map on variant change

### DIFF
--- a/src/visualBuilder/eventManager/__test__/useVariantsPostMessageEvent.spec.ts
+++ b/src/visualBuilder/eventManager/__test__/useVariantsPostMessageEvent.spec.ts
@@ -1,0 +1,492 @@
+import {
+    vi,
+    describe,
+    it,
+    expect,
+    beforeEach,
+    afterEach,
+    MockedObject,
+} from "vitest";
+import {
+    useVariantFieldsPostMessageEvent,
+    addVariantFieldClass,
+    removeVariantFieldClass,
+    setAudienceMode,
+    setVariant,
+    setLocale,
+} from "../../../visualBuilder/eventManager/useVariantsPostMessageEvent";
+import { VisualBuilderPostMessageEvents } from "../../../visualBuilder/utils/types/postMessage.types";
+import { VisualBuilder } from "../../../visualBuilder";
+import { FieldSchemaMap } from "../../../visualBuilder/utils/fieldSchemaMap";
+import { visualBuilderStyles } from "../../../visualBuilder/visualBuilder.style";
+import visualBuilderPostMessage from "../../../visualBuilder/utils/visualBuilderPostMessage";
+import { EventManager } from "@contentstack/advanced-post-message";
+
+const mockVisualBuilderPostMessage =
+    visualBuilderPostMessage as MockedObject<EventManager>;
+
+// Mock dependencies
+vi.mock("../../../visualBuilder/utils/visualBuilderPostMessage", () => {
+    return {
+        default: {
+            on: vi.fn(),
+            send: vi.fn(),
+        },
+    };
+});
+
+vi.mock("../../../visualBuilder/utils/fieldSchemaMap", () => {
+    return {
+        FieldSchemaMap: {
+            clear: vi.fn(),
+        },
+    };
+});
+
+vi.mock("../../../visualBuilder", () => {
+    return {
+        VisualBuilder: {
+            VisualBuilderGlobalState: {
+                value: {
+                    audienceMode: false,
+                    variant: null,
+                    locale: "en-us",
+                },
+            },
+        },
+    };
+});
+
+// Create a more realistic mock of the CSS modules
+const cssClassMock = "go655717959"; // Match the actual generated class name
+
+vi.mock("../../../visualBuilder.style", () => {
+    return {
+        visualBuilderStyles: () => ({
+            "visual-builder__variant-field": cssClassMock,
+        }),
+    };
+});
+
+// Mock DOM methods
+const mockElements = [
+    {
+        getAttribute: vi.fn().mockReturnValue("v2:variant-123"),
+        classList: {
+            add: vi.fn(),
+            remove: vi.fn(),
+        },
+    },
+    {
+        getAttribute: vi.fn().mockReturnValue("field-without-variant"),
+        classList: {
+            add: vi.fn(),
+            remove: vi.fn(),
+        },
+    },
+    {
+        getAttribute: vi.fn().mockReturnValue("v2:variant-456"),
+        classList: {
+            add: vi.fn(),
+            remove: vi.fn(),
+        },
+    },
+];
+
+const mockQuerySelectorAll = vi.fn().mockImplementation((selector) => {
+    // Return different mocks based on selector
+    if (selector === "[data-cslp]") {
+        return mockElements;
+    } else if (selector === `.${cssClassMock}`) {
+        return mockElements; // For onlyHighlighted=true case
+    } else if (
+        selector ===
+        ".visual-builder__disabled-variant-field, .visual-builder__variant-field, .visual-builder__base-field"
+    ) {
+        return mockElements; // For onlyHighlighted=false case
+    }
+
+    // Default fallback
+    return [];
+});
+
+describe("useVariantFieldsPostMessageEvent", () => {
+    // Store original document.querySelectorAll
+    const originalQuerySelectorAll = document.querySelectorAll;
+
+    beforeEach(() => {
+        // Mock document.querySelectorAll
+        document.querySelectorAll = mockQuerySelectorAll;
+
+        // Reset mocks
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        // Restore original methods
+        document.querySelectorAll = originalQuerySelectorAll;
+    });
+
+    it("should register all event listeners", () => {
+        // Call the function
+        useVariantFieldsPostMessageEvent();
+
+        // Verify event listeners are registered
+        expect(mockVisualBuilderPostMessage.on).toHaveBeenCalledWith(
+            VisualBuilderPostMessageEvents.GET_VARIANT_ID,
+            expect.any(Function)
+        );
+
+        expect(mockVisualBuilderPostMessage.on).toHaveBeenCalledWith(
+            VisualBuilderPostMessageEvents.GET_LOCALE,
+            expect.any(Function)
+        );
+
+        expect(mockVisualBuilderPostMessage.on).toHaveBeenCalledWith(
+            VisualBuilderPostMessageEvents.SET_AUDIENCE_MODE,
+            expect.any(Function)
+        );
+
+        expect(mockVisualBuilderPostMessage.on).toHaveBeenCalledWith(
+            VisualBuilderPostMessageEvents.SHOW_VARIANT_FIELDS,
+            expect.any(Function)
+        );
+
+        expect(mockVisualBuilderPostMessage.on).toHaveBeenCalledWith(
+            VisualBuilderPostMessageEvents.REMOVE_VARIANT_FIELDS,
+            expect.any(Function)
+        );
+    });
+
+    it("should handle GET_VARIANT_ID event", () => {
+        // Register event handlers
+        useVariantFieldsPostMessageEvent();
+
+        // Extract the event handler function
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.GET_VARIANT_ID
+        );
+        const handler = call ? call[1] : null;
+        expect(handler).not.toBeNull();
+
+        // Call the handler with mock event data
+        handler!({ data: { variant: "variant-123" } });
+
+        // Verify the handler sets the variant correctly
+        expect(VisualBuilder.VisualBuilderGlobalState.value.variant).toBe(
+            "variant-123"
+        );
+
+        // Verify FieldSchemaMap.clear was called
+        expect(FieldSchemaMap.clear).toHaveBeenCalled();
+    });
+
+    it("should handle GET_LOCALE event", () => {
+        // Register event handlers
+        useVariantFieldsPostMessageEvent();
+
+        // Extract the event handler function
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.GET_LOCALE
+        );
+        const handler = call ? call[1] : null;
+        expect(handler).not.toBeNull();
+
+        // Call the handler with mock event data
+        handler!({ data: { locale: "fr-fr" } });
+
+        // Verify the handler sets the locale correctly
+        expect(VisualBuilder.VisualBuilderGlobalState.value.locale).toBe(
+            "fr-fr"
+        );
+    });
+
+    it("should handle SET_AUDIENCE_MODE event", () => {
+        // Register event handlers
+        useVariantFieldsPostMessageEvent();
+
+        // Extract the event handler function
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.SET_AUDIENCE_MODE
+        );
+        const handler = call ? call[1] : null;
+        expect(handler).not.toBeNull();
+
+        // Call the handler with mock event data
+        handler!({ data: { audienceMode: true } });
+
+        // Verify the handler sets the audience mode correctly
+        expect(VisualBuilder.VisualBuilderGlobalState.value.audienceMode).toBe(
+            true
+        );
+    });
+
+    it("should handle SHOW_VARIANT_FIELDS event", () => {
+        // Register event handlers
+        useVariantFieldsPostMessageEvent();
+
+        // Extract the event handler function
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.SHOW_VARIANT_FIELDS
+        );
+        const handler = call ? call[1] : null;
+        expect(handler).not.toBeNull();
+
+        // Call the handler with mock event data
+        handler!({
+            data: {
+                variant_data: {
+                    variant: "variant-123",
+                    highlightVariantFields: true,
+                },
+            },
+        });
+
+        // Verify removeVariantFieldClass was called
+        expect(mockQuerySelectorAll).toHaveBeenCalledWith("[data-cslp]");
+
+        // Verify that classes were added to elements correctly
+        expect(mockElements[0].classList.add).toHaveBeenCalledWith(
+            visualBuilderStyles()["visual-builder__variant-field"]
+        );
+        expect(mockElements[0].classList.add).toHaveBeenCalledWith(
+            "visual-builder__variant-field"
+        );
+    });
+
+    it("should handle REMOVE_VARIANT_FIELDS event with onlyHighlighted=true", () => {
+        // Register event handlers
+        useVariantFieldsPostMessageEvent();
+
+        // Extract the event handler function
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.REMOVE_VARIANT_FIELDS
+        );
+        const handler = call ? call[1] : null;
+        expect(handler).not.toBeNull();
+
+        // Call the handler with mock event data
+        handler!({ data: { onlyHighlighted: true } });
+
+        // Verify querySelectorAll was called with the correct selector
+        expect(mockQuerySelectorAll).toHaveBeenCalledWith(
+            `.${visualBuilderStyles()["visual-builder__variant-field"]}`
+        );
+
+        // Verify that classes were removed from elements correctly
+        mockElements.forEach((element) => {
+            expect(element.classList.remove).toHaveBeenCalledWith(
+                visualBuilderStyles()["visual-builder__variant-field"]
+            );
+        });
+    });
+
+    it("should handle REMOVE_VARIANT_FIELDS event with onlyHighlighted=false", () => {
+        // Register event handlers
+        useVariantFieldsPostMessageEvent();
+
+        // Extract the event handler function
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.REMOVE_VARIANT_FIELDS
+        );
+        const handler = call ? call[1] : null;
+        expect(handler).not.toBeNull();
+
+        // Call the handler with mock event data
+        handler!({ data: { onlyHighlighted: false } });
+
+        // Verify querySelectorAll was called with the correct selector
+        expect(mockQuerySelectorAll).toHaveBeenCalledWith(
+            ".visual-builder__disabled-variant-field, .visual-builder__variant-field, .visual-builder__base-field"
+        );
+
+        // Verify that classes were removed from elements correctly
+        mockElements.forEach((element) => {
+            expect(element.classList.remove).toHaveBeenCalledWith(
+                "visual-builder__disabled-variant-field",
+                "visual-builder__variant-field",
+                visualBuilderStyles()["visual-builder__variant-field"],
+                "visual-builder__base-field"
+            );
+        });
+    });
+});
+
+describe("addVariantFieldClass", () => {
+    // Store original document.querySelectorAll
+    const originalQuerySelectorAll = document.querySelectorAll;
+
+    beforeEach(() => {
+        // Mock document.querySelectorAll
+        document.querySelectorAll = mockQuerySelectorAll;
+
+        // Reset mocks
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        // Restore original methods
+        document.querySelectorAll = originalQuerySelectorAll;
+    });
+
+    it("should add classes to elements correctly based on data-cslp attribute", () => {
+        const variantUid = "variant-123";
+        const highlightVariantFields = true;
+
+        addVariantFieldClass(variantUid, highlightVariantFields);
+
+        // Verify querySelectorAll was called with the correct selector
+        expect(mockQuerySelectorAll).toHaveBeenCalledWith("[data-cslp]");
+
+        // First element has the variant ID
+        expect(mockElements[0].getAttribute).toHaveBeenCalledWith("data-cslp");
+        expect(mockElements[0].classList.add).toHaveBeenCalledWith(
+            visualBuilderStyles()["visual-builder__variant-field"]
+        );
+        expect(mockElements[0].classList.add).toHaveBeenCalledWith(
+            "visual-builder__variant-field"
+        );
+
+        // Second element does not start with 'v2:'
+        expect(mockElements[1].getAttribute).toHaveBeenCalledWith("data-cslp");
+        expect(mockElements[1].classList.add).toHaveBeenCalledWith(
+            "visual-builder__base-field"
+        );
+
+        // Third element starts with 'v2:' but doesn't match variant
+        expect(mockElements[2].getAttribute).toHaveBeenCalledWith("data-cslp");
+        expect(mockElements[2].classList.add).toHaveBeenCalledWith(
+            "visual-builder__disabled-variant-field"
+        );
+    });
+
+    it("should not add highlight class when highlightVariantFields is false", () => {
+        const variantUid = "variant-123";
+        const highlightVariantFields = false;
+
+        addVariantFieldClass(variantUid, highlightVariantFields);
+
+        // First element has the variant ID but should not get highlight class
+        expect(mockElements[0].getAttribute).toHaveBeenCalledWith("data-cslp");
+        expect(mockElements[0].classList.add).not.toHaveBeenCalledWith(
+            visualBuilderStyles()["visual-builder__variant-field"]
+        );
+        expect(mockElements[0].classList.add).toHaveBeenCalledWith(
+            "visual-builder__variant-field"
+        );
+    });
+});
+
+describe("removeVariantFieldClass", () => {
+    // Store original document.querySelectorAll
+    const originalQuerySelectorAll = document.querySelectorAll;
+
+    beforeEach(() => {
+        // Mock document.querySelectorAll
+        document.querySelectorAll = mockQuerySelectorAll;
+
+        // Reset mocks
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        // Restore original methods
+        document.querySelectorAll = originalQuerySelectorAll;
+    });
+
+    it("should remove only highlighted variant field classes when onlyHighlighted=true", () => {
+        removeVariantFieldClass(true);
+
+        // Verify querySelectorAll was called with the correct selector
+        expect(mockQuerySelectorAll).toHaveBeenCalledWith(
+            `.${visualBuilderStyles()["visual-builder__variant-field"]}`
+        );
+
+        // Verify classes were removed
+        mockElements.forEach((element) => {
+            expect(element.classList.remove).toHaveBeenCalledWith(
+                visualBuilderStyles()["visual-builder__variant-field"]
+            );
+        });
+    });
+
+    it("should remove all variant field classes when onlyHighlighted=false", () => {
+        removeVariantFieldClass(false);
+
+        // Verify querySelectorAll was called with the correct selector
+        expect(mockQuerySelectorAll).toHaveBeenCalledWith(
+            ".visual-builder__disabled-variant-field, .visual-builder__variant-field, .visual-builder__base-field"
+        );
+
+        // Verify classes were removed
+        mockElements.forEach((element) => {
+            expect(element.classList.remove).toHaveBeenCalledWith(
+                "visual-builder__disabled-variant-field",
+                "visual-builder__variant-field",
+                visualBuilderStyles()["visual-builder__variant-field"],
+                "visual-builder__base-field"
+            );
+        });
+    });
+
+    it("should default to onlyHighlighted=false when parameter not provided", () => {
+        removeVariantFieldClass();
+
+        // Verify querySelectorAll was called with the correct selector
+        expect(mockQuerySelectorAll).toHaveBeenCalledWith(
+            ".visual-builder__disabled-variant-field, .visual-builder__variant-field, .visual-builder__base-field"
+        );
+    });
+});
+
+describe("State Management Functions", () => {
+    beforeEach(() => {
+        // Reset mocks
+        vi.clearAllMocks();
+
+        // Reset global state
+        VisualBuilder.VisualBuilderGlobalState.value.audienceMode = false;
+        VisualBuilder.VisualBuilderGlobalState.value.variant = null;
+        VisualBuilder.VisualBuilderGlobalState.value.locale = "en-us";
+    });
+
+    it("setAudienceMode should update global state", () => {
+        setAudienceMode(true);
+        expect(VisualBuilder.VisualBuilderGlobalState.value.audienceMode).toBe(
+            true
+        );
+
+        setAudienceMode(false);
+        expect(VisualBuilder.VisualBuilderGlobalState.value.audienceMode).toBe(
+            false
+        );
+    });
+
+    it("setVariant should update global state", () => {
+        setVariant("test-variant");
+        expect(VisualBuilder.VisualBuilderGlobalState.value.variant).toBe(
+            "test-variant"
+        );
+
+        setVariant(null);
+        expect(VisualBuilder.VisualBuilderGlobalState.value.variant).toBe(null);
+    });
+
+    it("setLocale should update global state", () => {
+        setLocale("fr-fr");
+        expect(VisualBuilder.VisualBuilderGlobalState.value.locale).toBe(
+            "fr-fr"
+        );
+
+        setLocale("en-us");
+        expect(VisualBuilder.VisualBuilderGlobalState.value.locale).toBe(
+            "en-us"
+        );
+    });
+});

--- a/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
+++ b/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
@@ -2,6 +2,7 @@ import { VisualBuilder } from "..";
 import { visualBuilderStyles } from "../visualBuilder.style";
 import visualBuilderPostMessage from "../utils/visualBuilderPostMessage";
 import { VisualBuilderPostMessageEvents } from "../utils/types/postMessage.types";
+import { FieldSchemaMap } from "../utils/fieldSchemaMap";
 
 interface VariantFieldsEvent {
     data: {
@@ -96,6 +97,12 @@ export function useVariantFieldsPostMessageEvent(): void {
         VisualBuilderPostMessageEvents.GET_VARIANT_ID,
         (event: VariantEvent) => {
             setVariant(event.data.variant);
+            // clear field schema when variant is changed.
+            // this is required as we cache field schema
+            // which contain a key isUnlinkedVariant.
+            // This key can change when variant is changed,
+            // so clear the field schema cache
+            FieldSchemaMap.clear();
         }
     );
     visualBuilderPostMessage?.on(

--- a/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
+++ b/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
@@ -34,7 +34,7 @@ interface LocaleEvent {
         locale: string;
     };
 }
-function addVariantFieldClass(
+export function addVariantFieldClass(
     variant_uid: string,
     highlightVariantFields: boolean
 ): void {
@@ -57,7 +57,9 @@ function addVariantFieldClass(
     });
 }
 
-function removeVariantFieldClass(onlyHighlighted: boolean = false): void {
+export function removeVariantFieldClass(
+    onlyHighlighted: boolean = false
+): void {
     if (onlyHighlighted) {
         const variantElements = document.querySelectorAll(
             `.${visualBuilderStyles()["visual-builder__variant-field"]}`
@@ -82,13 +84,13 @@ function removeVariantFieldClass(onlyHighlighted: boolean = false): void {
     }
 }
 
-function setAudienceMode(mode: boolean): void {
+export function setAudienceMode(mode: boolean): void {
     VisualBuilder.VisualBuilderGlobalState.value.audienceMode = mode;
 }
-function setVariant(uid: string | null): void {
+export function setVariant(uid: string | null): void {
     VisualBuilder.VisualBuilderGlobalState.value.variant = uid;
 }
-function setLocale(locale: string): void {
+export function setLocale(locale: string): void {
     VisualBuilder.VisualBuilderGlobalState.value.locale = locale;
 }
 

--- a/src/visualBuilder/utils/__test__/fieldSchemaMap.test.ts
+++ b/src/visualBuilder/utils/__test__/fieldSchemaMap.test.ts
@@ -54,6 +54,17 @@ describe("field Schema map", () => {
         expect(FieldSchemaMap.hasFieldSchema("test_ct", "title")).toBeFalsy();
     });
 
+    test("should clear the field schema promise map", () => {
+        // Create a promise by requesting a field schema
+        const promise = FieldSchemaMap.getFieldSchema("test_ct", "title");
+        // Clear the field schema map
+        FieldSchemaMap.clear();
+        // Request the same field schema again
+        const newPromise = FieldSchemaMap.getFieldSchema("test_ct", "title");
+        // If the promise map was cleared, these should be different promise objects
+        expect(newPromise).not.toBe(promise);
+    });
+
     test("should return true if the field schema maps are equal", () => {
         FieldSchemaMap.setFieldSchema(
             "test_ct",

--- a/src/visualBuilder/utils/fieldSchemaMap.ts
+++ b/src/visualBuilder/utils/fieldSchemaMap.ts
@@ -95,5 +95,6 @@ export class FieldSchemaMap {
      */
     static clear(): void {
         FieldSchemaMap.fieldSchema = {};
+        FieldSchemaMap.fieldSchemaPromise = {};
     }
 }


### PR DESCRIPTION
Clear field schema map on variant change as it contains a field - isUnlinkedVariant which depends on the current selected variant for its value.
The "get-variant-id" message is received from "Visual Builder" whenever the variant is changed.