### PR TITLE
fix: multiple reloads in timeline

### DIFF
--- a/src/livePreview/__test__/live-preview.test.ts
+++ b/src/livePreview/__test__/live-preview.test.ts
@@ -432,7 +432,7 @@ describe("incoming postMessage", () => {
 
 describe("testing window event listeners", () => {
     let addEventListenerMock: any;
-    let sendInitEvent = vi.fn().mockImplementation(mockLivePreviewInitEventListener);
+    const sendInitEvent = vi.fn().mockImplementation(mockLivePreviewInitEventListener);
     let livePreviewInstance: LivePreview;
 
     beforeEach(() => {

--- a/src/livePreview/eventManager/postMessageEvent.hooks.ts
+++ b/src/livePreview/eventManager/postMessageEvent.hooks.ts
@@ -1,6 +1,6 @@
 import Config, { setConfigFromParams } from "../../configManager/configManager";
 import { ILivePreviewWindowType } from "../../types/types";
-import { addParamsToUrl } from "../../utils";
+import { addParamsToUrl, isOpeningInTimeline } from "../../utils";
 import livePreviewPostMessage from "./livePreviewEventManager";
 import { LIVE_PREVIEW_POST_MESSAGE_EVENTS } from "./livePreviewEventManager.constant";
 import {
@@ -95,7 +95,7 @@ export function sendInitializeLivePreviewPostMessageEvent(): void {
                 //     "init message did not contain contentTypeUid or entryUid."
                 // );
             }
-            if (Config.get().ssr) {
+            if (Config.get().ssr || isOpeningInTimeline()) {
                 addParamsToUrl();
             }
             Config.set("windowType", windowType);

--- a/src/utils/addLivePreviewQueryTags.ts
+++ b/src/utils/addLivePreviewQueryTags.ts
@@ -8,10 +8,16 @@ export function addLivePreviewQueryTags(link: string): string {
         const ctUid: string | null =
             docUrl.searchParams.get("content_type_uid");
         const entryUid: string | null = docUrl.searchParams.get("entry_uid");
-        if (livePreviewHash && ctUid && entryUid) {
+        const previewTimestamp: string | null = docUrl.searchParams.get("preview_timestamp");
+        if (livePreviewHash) {
             newUrl.searchParams.set("live_preview", livePreviewHash);
+        }
+        if(ctUid && entryUid){
             newUrl.searchParams.set("content_type_uid", ctUid);
             newUrl.searchParams.set("entry_uid", entryUid);
+        }
+        if (previewTimestamp) {
+            newUrl.searchParams.set("preview_timestamp", previewTimestamp);
         }
         return newUrl.href;
     } catch (error) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,16 +7,23 @@ export { addLivePreviewQueryTags };
 export function addParamsToUrl() {
     // Setting the query params to all the click events related to current domain
     window.addEventListener("click", (event: any) => {
-        const target: any = event.target;
-        const targetHref: string | any = target.href;
+        const clickedElement = event.target;
+        const anchorElement = clickedElement.closest('a');
+        
+        // Only proceed if the clicked element is either an anchor or a direct/indirect child of an anchor
+        if (!anchorElement || !anchorElement.contains(clickedElement)) {
+            return;
+        }
+
+        const targetHref: string | any = anchorElement.href;
         const docOrigin: string = document.location.origin;
         if (
             targetHref &&
             targetHref.includes(docOrigin) &&
             !targetHref.includes("live_preview")
         ) {
-            const newUrl = addLivePreviewQueryTags(target.href);
-            event.target.href = newUrl || target.href;
+            const newUrl = addLivePreviewQueryTags(targetHref);
+            anchorElement.href = newUrl || targetHref;
         }
     });
 }


### PR DESCRIPTION
fix: multiple reloads in timeline
Ticket -> https://contentstack.atlassian.net/browse/VE-6673
Test Report -> 
<img width="971" height="84" alt="Screenshot 2025-07-11 at 16 43 01" src="https://github.com/user-attachments/assets/86ff4b48-9668-448a-a21d-0f639373bb81" />

This pull request introduces enhancements to the live preview functionality, focusing on improving query parameter handling, adding support for timeline-specific behavior, and refining event listener logic. The most important changes include updates to query parameter management, adjustments to event handling, and integration of timeline-specific checks.

### Query Parameter Handling Enhancements:
* [`src/utils/addLivePreviewQueryTags.ts`](diffhunk://#diff-5faee81be2d4fdc18aed05c48429bfb9ef08f4869bf041ad8f6693b6c62eebcbL11-R21): Added support for the `preview_timestamp` query parameter and refined logic for adding `live_preview`, `content_type_uid`, and `entry_uid` query parameters.
* [`src/utils/index.ts`](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99L10-R26): Improved handling of click events by ensuring query parameters are added only to valid anchor elements and their descendants.

### Timeline-Specific Behavior:
* [`src/livePreview/eventManager/postMessageEvent.hooks.ts`](diffhunk://#diff-794794e2eb037f6b3117cda2a2c9534d012314714fbc5e338f6c673ef96778f8L98-R98): Integrated `isOpeningInTimeline()` check to conditionally add query parameters when initializing live preview post messages.

### Event Listener Refinements:
* [`src/livePreview/__test__/live-preview.test.ts`](diffhunk://#diff-aee05fc77be462d4e3800b397210e1d6017dc77648ec64ea89011e2413e47b6bL435-R435): Changed `sendInitEvent` declaration from `let` to `const` for clarity and consistency.
* [`src/livePreview/eventManager/postMessageEvent.hooks.ts`](diffhunk://#diff-794794e2eb037f6b3117cda2a2c9534d012314714fbc5e338f6c673ef96778f8L3-R3): Imported `isOpeningInTimeline` utility for timeline-specific checks.
