### PR TITLE
Ve 6955 field location data fails to render when toolbar isnt mounted and event listener is missing

### DIFF
--- a/src/visualBuilder/components/FieldToolbar.tsx
+++ b/src/visualBuilder/components/FieldToolbar.tsx
@@ -392,17 +392,23 @@ function FieldToolbarComponent(
         };
     }, []);
 
+
+
     useEffect(() => {
-        const event = visualBuilderPostMessage?.on(
-            VisualBuilderPostMessageEvents.FIELD_LOCATION_DATA,
-            (data: { data: any }) => {
-                setFieldLocationData(data.data.fieldLocationData);
+        const fetchFieldLocationData = async () => {
+            try {
+                const event = await visualBuilderPostMessage?.send(VisualBuilderPostMessageEvents.FIELD_LOCATION_DATA, {
+                    domEditStack: getDOMEditStack(eventDetails.editableElement)
+                });
+               
+                setFieldLocationData(event)
+            } catch (error) {
+                console.error('Error fetching field location data:', error);
             }
-        );
-        return () => {
-            event?.unregister();
         };
-    }, []);
+
+        fetchFieldLocationData();
+    }, [eventDetails.editableElement]);
 
     const multipleFieldToolbarButtonClasses = classNames(
         "visual-builder__button visual-builder__button--secondary",


### PR DESCRIPTION
This Pr modifies the way we were fetching field location data 