### PR TITLE
feat: live preview: added outside iframe code

### DIFF
--- a/src/livePreview/eventManager/livePreviewEventManager.constant.ts
+++ b/src/livePreview/eventManager/livePreviewEventManager.constant.ts
@@ -5,6 +5,7 @@ export const LIVE_PREVIEW_POST_MESSAGE_EVENTS = {
     CHECK_ENTRY_PAGE: "check-entry-page",
     URL_CHANGE: "url-change",
     VARIANT_PATCH: "variant-patch-update",
+    ON_RELOAD: "cslp-reload"
 } as const;
 
 export const LIVE_PREVIEW_CHANNEL_ID = "live-preview";

--- a/src/livePreview/eventManager/livePreviewEventManager.ts
+++ b/src/livePreview/eventManager/livePreviewEventManager.ts
@@ -4,11 +4,17 @@ import { LIVE_PREVIEW_CHANNEL_ID } from "./livePreviewEventManager.constant";
 let livePreviewPostMessage: EventManager | undefined;
 
 if (typeof window !== "undefined") {
-    livePreviewPostMessage = new EventManager(LIVE_PREVIEW_CHANNEL_ID, {
+    let eventOptions = {
         target: window.parent,
         debug: false,
-        suppressErrors: true,
-    });
+        suppressErrors: true
+    };
+
+    if (window.opener) {
+        eventOptions.target = window.opener;
+    }
+
+    livePreviewPostMessage = new EventManager(LIVE_PREVIEW_CHANNEL_ID, eventOptions);
 }
 
 export default livePreviewPostMessage;

--- a/src/livePreview/eventManager/postMessageEvent.hooks.ts
+++ b/src/livePreview/eventManager/postMessageEvent.hooks.ts
@@ -7,6 +7,7 @@ import {
     HistoryLivePreviewPostMessageEventData,
     LivePreviewInitEventResponse,
     OnChangeLivePreviewPostMessageEventData,
+    OnReloadLivePreviewPostMessageEventData,
 } from "./types/livePreviewPostMessageEvent.type";
 
 /**
@@ -52,6 +53,20 @@ export function useOnEntryUpdatePostMessageEvent(): void {
             const { ssr, onChange } = Config.get();
             if (!ssr) {
                 onChange();
+            }
+        }
+    );
+}
+
+export function useOnReloadPostMessageEvent(): void {
+    livePreviewPostMessage?.on<OnReloadLivePreviewPostMessageEventData>(
+        LIVE_PREVIEW_POST_MESSAGE_EVENTS.ON_RELOAD,
+        (event) => {
+            setConfigFromParams({
+                live_preview: event.data.hash,
+            });
+            if (window) {
+                window.location?.reload();
             }
         }
     );
@@ -109,6 +124,7 @@ export function sendInitializeLivePreviewPostMessageEvent(): void {
 
             useHistoryPostMessageEvent();
             useOnEntryUpdatePostMessageEvent();
+            useOnReloadPostMessageEvent();
         })
         .catch((e) => {
             // TODO: add debug logs that runs conditionally

--- a/src/livePreview/eventManager/types/livePreviewPostMessageEvent.type.ts
+++ b/src/livePreview/eventManager/types/livePreviewPostMessageEvent.type.ts
@@ -8,6 +8,10 @@ export interface OnChangeLivePreviewPostMessageEventData {
     hash: string;
 }
 
+export interface OnReloadLivePreviewPostMessageEventData {
+    hash: string;
+}
+
 export interface LivePreviewInitEventResponse {
     contentTypeUid: string;
     entryUid: string;


### PR DESCRIPTION
This pull request introduces a new `ON_RELOAD` event to the live preview system, enabling enhanced functionality for handling reload scenarios. The changes span multiple files, adding support for the new event and ensuring proper integration into the live preview event manager and hooks.

### Addition of `ON_RELOAD` event:

- **Constant definition**: Added `ON_RELOAD` to the `LIVE_PREVIEW_POST_MESSAGE_EVENTS` object in `src/livePreview/eventManager/livePreviewEventManager.constant.ts`.
- **Event handling**: Updated the `EventManager` initialization in `src/livePreview/eventManager/livePreviewEventManager.ts` to dynamically set the `target` based on the presence of `window.opener`.

### Integration into hooks:

- **New hook**: Created `useOnReloadPostMessageEvent` in `src/livePreview/eventManager/postMessageEvent.hooks.ts` to listen for the `ON_RELOAD` event and reload the page with updated parameters.
- **Hook usage**: Integrated `useOnReloadPostMessageEvent` into the initialization flow in `sendInitializeLivePreviewPostMessageEvent`.

### Type definition:

- **Event data type**: Added `OnReloadLivePreviewPostMessageEventData` interface in `src/livePreview/eventManager/types/livePreviewPostMessageEvent.type.ts` to define the structure of the `ON_RELOAD` event payload.