### PR TITLE
Revert "Ve 6955 field location data fails to render when toolbar isnt mounted and event listener is missing"

### DIFF
--- a/src/visualBuilder/components/FieldToolbar.tsx
+++ b/src/visualBuilder/components/FieldToolbar.tsx
@@ -392,23 +392,17 @@ function FieldToolbarComponent(
         };
     }, []);
 
-
-
     useEffect(() => {
-        const fetchFieldLocationData = async () => {
-            try {
-                const event = await visualBuilderPostMessage?.send(VisualBuilderPostMessageEvents.FIELD_LOCATION_DATA, {
-                    domEditStack: getDOMEditStack(eventDetails.editableElement)
-                });
-               
-                setFieldLocationData(event)
-            } catch (error) {
-                console.error('Error fetching field location data:', error);
+        const event = visualBuilderPostMessage?.on(
+            VisualBuilderPostMessageEvents.FIELD_LOCATION_DATA,
+            (data: { data: any }) => {
+                setFieldLocationData(data.data.fieldLocationData);
             }
+        );
+        return () => {
+            event?.unregister();
         };
-
-        fetchFieldLocationData();
-    }, [eventDetails.editableElement]);
+    }, []);
 
     const multipleFieldToolbarButtonClasses = classNames(
         "visual-builder__button visual-builder__button--secondary",


### PR DESCRIPTION
Reverts contentstack/live-preview-sdk#462