### PR TITLE
feat: live preview: added outside iframe code

### DIFF
--- a/src/common/inIframe.ts
+++ b/src/common/inIframe.ts
@@ -5,3 +5,11 @@ export function inIframe(): boolean {
         return true;
     }
 }
+
+export function inNewTab(): boolean {
+    try {
+        return !!window.opener;
+    } catch (e) {
+        return false;
+    }
+}

--- a/src/livePreview/editButton/editButton.ts
+++ b/src/livePreview/editButton/editButton.ts
@@ -1,5 +1,5 @@
 import { effect } from "@preact/signals";
-import { inIframe } from "../../common/inIframe";
+import { inIframe, inNewTab } from "../../common/inIframe";
 import Config from "../../configManager/configManager";
 import { addCslpOutline, extractDetailsFromCslp } from "../../cslp";
 import { cslpTagStyles } from "./editButton.style";
@@ -448,7 +448,7 @@ export class LivePreviewEditButton {
                 fieldPathWithIndex,
             } = extractDetailsFromCslp(cslpTag);
 
-            if (inIframe()) {
+            if (inIframe() || inNewTab()) {
                 livePreviewPostMessage?.send("scroll", {
                     field: fieldPathWithIndex,
                     content_type_uid,

--- a/src/livePreview/eventManager/livePreviewEventManager.constant.ts
+++ b/src/livePreview/eventManager/livePreviewEventManager.constant.ts
@@ -5,7 +5,6 @@ export const LIVE_PREVIEW_POST_MESSAGE_EVENTS = {
     CHECK_ENTRY_PAGE: "check-entry-page",
     URL_CHANGE: "url-change",
     VARIANT_PATCH: "variant-patch-update",
-    ON_RELOAD: "cslp-reload"
 } as const;
 
 export const LIVE_PREVIEW_CHANNEL_ID = "live-preview";

--- a/src/livePreview/eventManager/livePreviewEventManager.ts
+++ b/src/livePreview/eventManager/livePreviewEventManager.ts
@@ -1,16 +1,17 @@
 import { EventManager } from "@contentstack/advanced-post-message";
 import { LIVE_PREVIEW_CHANNEL_ID } from "./livePreviewEventManager.constant";
+import { inNewTab } from "../../common/inIframe";
 
 let livePreviewPostMessage: EventManager | undefined;
 
 if (typeof window !== "undefined") {
-    let eventOptions = {
+    const eventOptions = {
         target: window.parent,
         debug: false,
         suppressErrors: true
     };
 
-    if (window.opener) {
+    if (inNewTab()) {
         eventOptions.target = window.opener;
     }
 

--- a/src/livePreview/eventManager/postMessageEvent.hooks.ts
+++ b/src/livePreview/eventManager/postMessageEvent.hooks.ts
@@ -51,7 +51,6 @@ export function useOnEntryUpdatePostMessageEvent(): void {
             try {
                 const { ssr, onChange } = Config.get();
                 const event_type = event.data._metadata?.event_type;
-                console.log("on change event", event.data);
                 setConfigFromParams({
                     live_preview: event.data.hash,
                 });
@@ -75,15 +74,12 @@ export function useOnEntryUpdatePostMessageEvent(): void {
                 if(event_type === OnChangeLivePreviewPostMessageEventTypes.HASH_CHANGE){
                     const newUrl = new URL(window.location.href);
                     newUrl.searchParams.set("live_preview", event.data.hash);
-                    console.log("on change event newUrl", newUrl.toString());
                     window.history.pushState({}, "", newUrl.toString());
                 }
 
                 // This section will run when the URL of the page changes
-                if(event_type === OnChangeLivePreviewPostMessageEventTypes.URL_CHANGE){
-                    if(event.data.url){
-                        window.location.href = event.data.url;
-                    }
+                if(event_type === OnChangeLivePreviewPostMessageEventTypes.URL_CHANGE && event.data.url){
+                    window.location.href = event.data.url;
                 }
             } catch (error) {
                 PublicLogger.error("Error handling live preview update:", error);

--- a/src/livePreview/eventManager/postMessageEvent.hooks.ts
+++ b/src/livePreview/eventManager/postMessageEvent.hooks.ts
@@ -1,4 +1,5 @@
 import Config, { setConfigFromParams } from "../../configManager/configManager";
+import { PublicLogger } from "../../logger/logger";
 import { ILivePreviewWindowType } from "../../types/types";
 import { addParamsToUrl } from "../../utils";
 import livePreviewPostMessage from "./livePreviewEventManager";
@@ -7,7 +8,7 @@ import {
     HistoryLivePreviewPostMessageEventData,
     LivePreviewInitEventResponse,
     OnChangeLivePreviewPostMessageEventData,
-    OnReloadLivePreviewPostMessageEventData,
+    OnChangeLivePreviewPostMessageEventTypes,
 } from "./types/livePreviewPostMessageEvent.type";
 
 /**
@@ -47,26 +48,46 @@ export function useOnEntryUpdatePostMessageEvent(): void {
     livePreviewPostMessage?.on<OnChangeLivePreviewPostMessageEventData>(
         LIVE_PREVIEW_POST_MESSAGE_EVENTS.ON_CHANGE,
         (event) => {
-            setConfigFromParams({
-                live_preview: event.data.hash,
-            });
-            const { ssr, onChange } = Config.get();
-            if (!ssr) {
-                onChange();
-            }
-        }
-    );
-}
+            try {
+                const { ssr, onChange } = Config.get();
+                const event_type = event.data._metadata?.event_type;
+                console.log("on change event", event.data);
+                setConfigFromParams({
+                    live_preview: event.data.hash,
+                });
 
-export function useOnReloadPostMessageEvent(): void {
-    livePreviewPostMessage?.on<OnReloadLivePreviewPostMessageEventData>(
-        LIVE_PREVIEW_POST_MESSAGE_EVENTS.ON_RELOAD,
-        (event) => {
-            setConfigFromParams({
-                live_preview: event.data.hash,
-            });
-            if (window) {
-                window.location?.reload();
+                // This section will run when there is a change in the entry and the website is CSR
+                if (!ssr && !event_type) {
+                    onChange();
+                } 
+
+                if(!window) {
+                    PublicLogger.error("window is not defined");
+                    return;
+                };
+                
+                // This section will run when there is a change in the entry and the website is SSR
+                if(ssr && !event_type) {
+                    window.location.reload();
+                }
+
+                // This section will run when the hash changes and the website is SSR or CSR
+                if(event_type === OnChangeLivePreviewPostMessageEventTypes.HASH_CHANGE){
+                    const newUrl = new URL(window.location.href);
+                    newUrl.searchParams.set("live_preview", event.data.hash);
+                    console.log("on change event newUrl", newUrl.toString());
+                    window.history.pushState({}, "", newUrl.toString());
+                }
+
+                // This section will run when the URL of the page changes
+                if(event_type === OnChangeLivePreviewPostMessageEventTypes.URL_CHANGE){
+                    if(event.data.url){
+                        window.location.href = event.data.url;
+                    }
+                }
+            } catch (error) {
+                PublicLogger.error("Error handling live preview update:", error);
+                return;
             }
         }
     );
@@ -124,7 +145,6 @@ export function sendInitializeLivePreviewPostMessageEvent(): void {
 
             useHistoryPostMessageEvent();
             useOnEntryUpdatePostMessageEvent();
-            useOnReloadPostMessageEvent();
         })
         .catch((e) => {
             // TODO: add debug logs that runs conditionally

--- a/src/livePreview/eventManager/types/livePreviewPostMessageEvent.type.ts
+++ b/src/livePreview/eventManager/types/livePreviewPostMessageEvent.type.ts
@@ -1,15 +1,22 @@
 import { ILivePreviewWindowType } from "../../../types/types";
 
+export const OnChangeLivePreviewPostMessageEventTypes = {
+    HASH_CHANGE: "hash_change",
+    URL_CHANGE: "url_change"
+} as const;
+
 export interface HistoryLivePreviewPostMessageEventData {
     type: "forward" | "backward" | "reload";
 }
 
 export interface OnChangeLivePreviewPostMessageEventData {
     hash: string;
-}
-
-export interface OnReloadLivePreviewPostMessageEventData {
-    hash: string;
+    entry_uid?: string;
+    content_type_uid?: string;
+    url?: string;
+    _metadata?: {
+        event_type: typeof OnChangeLivePreviewPostMessageEventTypes[keyof typeof OnChangeLivePreviewPostMessageEventTypes];
+    }
 }
 
 export interface LivePreviewInitEventResponse {


### PR DESCRIPTION
Summary
These commits introduce comprehensive support for live preview functionality when content is opened in new tabs (instead of iframes) and significantly improve Server-Side Rendering (SSR) handling with enhanced event management.

Key Changes
1. New Tab Detection & Support
Added inNewTab() utility function to detect when content is opened in a new browser tab
Modified event manager to target window.opener instead of window.parent for new tab scenarios
Updated edit button behavior to handle both iframe and new tab contexts
2. Enhanced SSR Handling
Implemented differentiated handling for Client-Side Rendering (CSR) vs Server-Side Rendering (SSR)
Added automatic page reload for SSR websites when entry content changes
Introduced event type metadata to distinguish between different update scenarios
3. Advanced Event Management
Added new event types: HASH_CHANGE and URL_CHANGE for granular control
Implemented proper URL parameter updates using history.pushState() for hash changes
Added robust error handling with logging for post message events
Enhanced type definitions for live preview event data
4. Bug Fixes & Cleanup
Fixed URL change handling logic with proper null checking
Removed debug console statements from production code
Improved error boundaries around window operations