### PR TITLE
fix: removed edit icon when the click is on the container

### DIFF
--- a/src/visualBuilder/components/FieldToolbar.tsx
+++ b/src/visualBuilder/components/FieldToolbar.tsx
@@ -163,7 +163,7 @@ function FieldToolbarComponent(
         disableFieldActions = isDisabled;
 
         fieldType = getFieldType(fieldSchema);
-        isModalEditable = ALLOWED_MODAL_EDITABLE_FIELD.includes(fieldType);
+     
 
         Icon = fieldIcons[fieldType];
 
@@ -184,6 +184,8 @@ function FieldToolbarComponent(
             (fieldMetadata.fieldPathWithIndex ===
                 fieldMetadata.instance.fieldPathWithIndex ||
                 fieldMetadata.multipleFieldMetadata?.index === -1);
+
+        isModalEditable = ALLOWED_MODAL_EDITABLE_FIELD.includes(fieldType) && !isWholeMultipleField;
 
         isReplaceAllowed =
             ALLOWED_REPLACE_FIELDS.includes(fieldType) && !isWholeMultipleField;


### PR DESCRIPTION
This PR fixes the issue where a 'Something went wrong' error appeared when opening the field edit modal, specifically when the JSON RTE container was selected.