### PR TITLE
VB-476:- fix(VB-476/open-experience-editig-message-clear): message updated

### DIFF
--- a/src/visualBuilder/utils/isFieldDisabled.ts
+++ b/src/visualBuilder/utils/isFieldDisabled.ts
@@ -10,7 +10,7 @@ const DisableReason = {
     LocalizedEntry: "Editing this field is restricted in localized entries",
     UnlinkedVariant:
         "This field is not editable as it is not linked to the selected variant",
-    AudienceMode: "Open an Experience from Audience widget to start editing",
+    AudienceMode: "To edit an experience, open the Audience widget and select the Edit icon.",
     DisabledVariant:
         "This field is not editable as it doesn't match the selected variant",
     UnlocalizedVariant: "This field is not editable as it is not localized",


### PR DESCRIPTION
MeWhen we open an experience and try to edit anything this message is shown - “Open An Experience from Audience Widget to start editing” which is not very clear. User has already opened audience widget and selected audiences to reach that variant. The edit button on the Experience in side panel is for editing the content in canvas is not very clearly mentioned anywhere.