### PR TITLE
fix(security): bump dompurify from ^3.4.0 to ^3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "classnames": "^2.5.1",
                 "dayjs": "^1.11.13",
                 "deepsignal": "^1.5.0",
-                "dompurify": "^3.4.0",
+                "dompurify": "^3.4.1",
                 "get-xpath": "^3.2.0",
                 "goober": "^2.1.16",
                 "lodash-es": "^4.18.1",
@@ -3681,9 +3681,9 @@
             "dev": true
         },
         "node_modules/dompurify": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+            "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "classnames": "^2.5.1",
         "dayjs": "^1.11.13",
         "deepsignal": "^1.5.0",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.1",
         "get-xpath": "^3.2.0",
         "goober": "^2.1.16",
         "lodash-es": "^4.18.1",


### PR DESCRIPTION
## Title

fix(security): bump dompurify from ^3.4.0 to ^3.4.1

## Description

Bumps `dompurify` to `^3.4.1` to fix three Snyk vulnerabilities:

- `SNYK-JS-DOMPURIFY-16078387` — Operator Precedence Logic Error (medium) — VB-1385
- `SNYK-JS-DOMPURIFY-16132234` — Cross-site Scripting XSS (medium) — VB-1413
- `SNYK-JS-DOMPURIFY-16131135` — Cross-site Scripting XSS (low) — VB-1414

Ticket: [VB-1385](https://contentstack.atlassian.net/browse/VB-1385)

## Type of Change

- [x] Bugfix

## Testing

### Unit Tests

Dependency version bump only — no functional changes. Existing test suite covers dompurify usage.

### End-to-End Tests

N/A

## Checklist for Contributors

- [x] Code is well-documented.
- [x] Install the dependency and run build locally.
- [x] All tests pass.
- [x] Changes have been tested locally.
- [x] Commit messages are clear, descriptive, and follow our commit format.

## Additional Notes

VB-1344 (`lodash-es`) and VB-1412 (`uuid`) remain blocked — both are already at the latest published versions with no upstream fix available yet.


[VB-1385]: https://contentstack.atlassian.net/browse/VB-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ