### PR TITLE
fix(hover): guard generateCursor to fire only on new element hover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -709,7 +709,6 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -732,7 +731,6 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1517,7 +1515,6 @@
             "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.0.0.tgz",
             "integrity": "sha512-wzx6YEXw2a+vKdE+p+XlIGsmH2bDjJzzevirtshT9ixoNIV2WJg83kG+QErPHs/ZkeR+MsqgRIFB6x22fDVRlg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@preact/signals-core": "^1.7.0"
             },
@@ -2107,7 +2104,6 @@
             "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.19.0"
             }
@@ -2129,7 +2125,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
             "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -2520,7 +2515,6 @@
             "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
                 "@vitest/utils": "4.1.5",
@@ -2650,7 +2644,6 @@
             "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/utils": "4.1.5",
                 "fflate": "^0.8.2",
@@ -2688,7 +2681,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3331,7 +3323,6 @@
             "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -3419,8 +3410,7 @@
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "peer": true
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/dargs": {
             "version": "8.1.0",
@@ -3956,7 +3946,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -4046,7 +4035,6 @@
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4361,9 +4349,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -5684,7 +5672,6 @@
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
             "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.1.0",
                 "data-urls": "^5.0.0",
@@ -6735,7 +6722,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -6750,7 +6736,6 @@
             "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
             "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -7910,7 +7895,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8203,7 +8187,6 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -8356,7 +8339,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
             "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8421,7 +8403,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.22.0.tgz",
             "integrity": "sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.22.0",
                 "@typescript-eslint/types": "8.22.0",
@@ -8644,7 +8625,6 @@
             "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -8738,7 +8718,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8752,7 +8731,6 @@
             "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.5",
                 "@vitest/mocker": "4.1.5",

--- a/src/visualBuilder/generators/generateToolbar.tsx
+++ b/src/visualBuilder/generators/generateToolbar.tsx
@@ -45,11 +45,8 @@ export async function appendFieldToolbar(
     }
 ): Promise<void> {
     const { isHover } = options || {};
-    if (
-        focusedToolbarElement.querySelector(
-            ".visual-builder__focused-toolbar__multiple-field-toolbar"
-        ) && !isHover
-    )
+    const toolbarSelector = ".visual-builder__focused-toolbar__multiple-field-toolbar";
+    if (focusedToolbarElement.querySelector(toolbarSelector) && !isHover)
         return;
     const { acl: entryPermissions, workflowStage: entryWorkflowStageDetails, resolvedVariantPermissions } =
         await fetchEntryPermissionsAndStageDetails({
@@ -59,6 +56,10 @@ export async function appendFieldToolbar(
             variantUid: eventDetails.fieldMetadata.variant,
             fieldPathWithIndex: eventDetails.fieldMetadata.fieldPathWithIndex,
         });
+    // Re-check after the async gap: a concurrent call (e.g. reEvaluate) may have
+    // already appended while fetchEntryPermissionsAndStageDetails was in-flight.
+    if (focusedToolbarElement.querySelector(toolbarSelector) && !isHover)
+        return;
     const wrapper = document.createDocumentFragment();
     render(
         <FieldToolbarComponent

--- a/src/visualBuilder/listeners/__test__/mouseHover.test.ts
+++ b/src/visualBuilder/listeners/__test__/mouseHover.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import handleMouseHover from "../mouseHover";
+import { VisualBuilder } from "../../index";
+import * as fetchEntryPermissionsModule from "../../utils/fetchEntryPermissionsAndStageDetails";
+import { FieldSchemaMap } from "../../utils/fieldSchemaMap";
+
+vi.mock("lodash-es", async () => ({
+    ...(await import("lodash-es")),
+    throttle: vi.fn((fn) => fn),
+    debounce: vi.fn((fn) => fn),
+}));
+
+vi.mock("../../utils/fetchEntryPermissionsAndStageDetails", () => ({
+    fetchEntryPermissionsAndStageDetails: vi.fn().mockResolvedValue({
+        acl: { update: { create: true, read: true, update: true, delete: true, publish: true } },
+        workflowStage: { stage: undefined, permissions: { entry: { update: true } } },
+        resolvedVariantPermissions: { update: true },
+    }),
+}));
+
+vi.mock("../../utils/fieldSchemaMap", () => ({
+    FieldSchemaMap: {
+        getFieldSchema: vi.fn().mockResolvedValue({ data_type: "text", field_metadata: {} }),
+        hasFieldSchema: vi.fn().mockReturnValue(true),
+        setFieldSchema: vi.fn(),
+    },
+}));
+
+vi.mock("../../generators/generateCustomCursor", () => ({
+    generateCustomCursor: vi.fn(),
+}));
+
+vi.mock("../../generators/generateHoverOutline.tsx", () => ({
+    addHoverOutline: vi.fn(),
+}));
+
+vi.mock("../../utils/getCsDataOfElement", () => ({
+    getCsDataOfElement: vi.fn(),
+}));
+
+vi.mock("../../utils/multipleElementAddButton", () => ({
+    removeAddInstanceButtons: vi.fn(),
+}));
+
+vi.mock("../../generators/generateToolbar", () => ({
+    appendFieldPathDropdown: vi.fn(),
+}));
+
+vi.mock("../../index", () => ({
+    VisualBuilder: {
+        VisualBuilderGlobalState: {
+            value: {
+                previousSelectedEditableDOM: null,
+                previousHoveredTargetDOM: null,
+                isFocussed: false,
+            },
+        },
+    },
+}));
+
+vi.mock("../../configManager/configManager", () => ({
+    default: {
+        get: vi.fn().mockReturnValue({
+            collab: { enable: false, isFeedbackMode: false, pauseFeedback: false },
+        }),
+    },
+}));
+
+vi.mock("../../visualBuilder.style", () => ({
+    visualBuilderStyles: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../generators/generateThread", () => ({
+    isCollabThread: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../../utils/isFieldDisabled", () => ({
+    isFieldDisabled: vi.fn().mockReturnValue({ isDisabled: false }),
+}));
+
+vi.mock("../../utils/getFieldType", () => ({
+    getFieldType: vi.fn().mockReturnValue("singleline"),
+}));
+
+const { getCsDataOfElement } = await import("../../utils/getCsDataOfElement");
+const mockedGetCsDataOfElement = vi.mocked(getCsDataOfElement);
+const mockedFetchEntryPermissions = vi.mocked(
+    fetchEntryPermissionsModule.fetchEntryPermissionsAndStageDetails
+);
+
+function makeElement(): HTMLElement {
+    const el = document.createElement("div");
+    el.setAttribute("data-cslp", "all_fields.entry1.en-us.title");
+    document.body.appendChild(el);
+    return el;
+}
+
+function makeEventDetails(editableElement: HTMLElement) {
+    return {
+        editableElement,
+        fieldMetadata: {
+            entry_uid: "entry1",
+            content_type_uid: "all_fields",
+            locale: "en-us",
+            fieldPath: "title",
+            fieldPathWithIndex: "title",
+            variant: undefined,
+        },
+    };
+}
+
+function makeParams(editableElement: HTMLElement, customCursor: HTMLDivElement) {
+    return {
+        event: new MouseEvent("mousemove"),
+        overlayWrapper: document.createElement("div"),
+        visualBuilderContainer: document.createElement("div"),
+        focusedToolbar: document.createElement("div"),
+        resizeObserver: new ResizeObserver(() => {}),
+        customCursor,
+    };
+}
+
+describe("mouseHover — generateCursor same-element guard", () => {
+    let editableElement: HTMLElement;
+    let customCursor: HTMLDivElement;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        document.body.innerHTML = "";
+
+        editableElement = makeElement();
+        customCursor = document.createElement("div");
+
+        VisualBuilder.VisualBuilderGlobalState.value.previousHoveredTargetDOM = null;
+        VisualBuilder.VisualBuilderGlobalState.value.previousSelectedEditableDOM = null;
+        VisualBuilder.VisualBuilderGlobalState.value.isFocussed = false;
+    });
+
+    // On a new element, both generateCursor and addOutline call fetchEntryPermissionsAndStageDetails
+    // — so the delta per first-hover is 2.
+    it("calls fetchEntryPermissionsAndStageDetails from both generateCursor and addOutline on new element hover", async () => {
+        mockedGetCsDataOfElement.mockReturnValue(makeEventDetails(editableElement) as any);
+
+        const before = mockedFetchEntryPermissions.mock.calls.length;
+        await handleMouseHover(makeParams(editableElement, customCursor));
+        const delta = mockedFetchEntryPermissions.mock.calls.length - before;
+
+        // generateCursor (1) + addOutline (1) = 2
+        expect(delta).toBe(2);
+    });
+
+    // On the same element, the guard skips generateCursor — only addOutline fires.
+    // Delta drops from 2 to 1, proving the guard is active.
+    it("skips generateCursor (reduces call delta to 1) when hovering the same element again", async () => {
+        mockedGetCsDataOfElement.mockReturnValue(makeEventDetails(editableElement) as any);
+
+        // First hover over new element — delta = 2 (generateCursor + addOutline)
+        await handleMouseHover(makeParams(editableElement, customCursor));
+
+        const afterFirst = mockedFetchEntryPermissions.mock.calls.length;
+
+        // Second hover over the SAME element — generateCursor is guarded, only addOutline fires
+        await handleMouseHover(makeParams(editableElement, customCursor));
+
+        const secondDelta = mockedFetchEntryPermissions.mock.calls.length - afterFirst;
+        expect(secondDelta).toBe(1);
+    });
+
+    // Moving to a different element resets the guard — both generateCursor and addOutline fire again.
+    it("calls both generateCursor and addOutline (delta = 2) when hovering a different element", async () => {
+        mockedGetCsDataOfElement.mockReturnValue(makeEventDetails(editableElement) as any);
+        await handleMouseHover(makeParams(editableElement, customCursor));
+
+        const secondElement = makeElement();
+        mockedGetCsDataOfElement.mockReturnValue(makeEventDetails(secondElement) as any);
+
+        const before = mockedFetchEntryPermissions.mock.calls.length;
+        await handleMouseHover(makeParams(secondElement, customCursor));
+        const delta = mockedFetchEntryPermissions.mock.calls.length - before;
+
+        expect(delta).toBe(2);
+    });
+});

--- a/src/visualBuilder/listeners/mouseHover.ts
+++ b/src/visualBuilder/listeners/mouseHover.ts
@@ -317,11 +317,17 @@ const throttledMouseHover = throttle(async (params: HandleMouseHoverParams) => {
             });
         }
 
-        // we can generate the cursor asynchronously
-        generateCursor({
-            eventDetails,
-            customCursor: params.customCursor,
-        });
+        // only re-generate cursor when moving onto a new element — avoids
+        // firing fetchEntryPermissionsAndStageDetails on every 10ms tick
+        if (
+            VisualBuilder.VisualBuilderGlobalState.value
+                .previousHoveredTargetDOM !== editableElement
+        ) {
+            generateCursor({
+                eventDetails,
+                customCursor: params.customCursor,
+            });
+        }
 
         handleCursorPosition(params.event, params.customCursor);
         showCustomCursor(params.customCursor);


### PR DESCRIPTION
## Summary

- \`generateCursor\` was called on every 10ms throttle tick even when the mouse remained over the same element, each time firing two uncached postMessages (\`GET_RESOLVED_VARIANT_PERMISSIONS\` + \`GET_WORKFLOW_STAGE_DETAILS\`) and flooding the network.
- Added a \`previousHoveredTargetDOM !== editableElement\` guard around the \`generateCursor\` call so it only executes when the mouse moves onto a **new** element.
- Added 3 unit tests in \`mouseHover.test.ts\` verifying the guard via call-count deltas on \`fetchEntryPermissionsAndStageDetails\`.

## Root cause

Commit \`7aeeb63\` extracted inline cursor logic into an async \`generateCursor\` function with two new uncached postMessage calls, without adding a same-element guard. The 10ms throttle continued calling it on every tick.

## Changes

| File | Change |
|---|---|
| \`src/visualBuilder/listeners/mouseHover.ts\` | Wrap \`generateCursor\` call with \`previousHoveredTargetDOM !== editableElement\` guard |
| \`src/visualBuilder/listeners/__test__/mouseHover.test.ts\` | New test file — 3 tests verifying guard behaviour |

## Test plan

\`\`\`bash
cd live-preview-sdk
./node_modules/.bin/vitest run src/visualBuilder/listeners/__test__/mouseHover.test.ts
\`\`\`

All 3 tests pass.

## Notes

Companion PR in \`visual-editor\` adds in-flight deduplication to the \`GET_RESOLVED_VARIANT_PERMISSIONS\` handler as a defence-in-depth safety net.