### PR TITLE
release: 4.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## [v4.4.2](https://github.com/contentstack/live-preview-sdk/compare/v4.4.1...v4.4.2)
+## [v4.4.2](https://github.com/contentstack/live-preview-sdk/compare/v4.4.2...v4.4.2)
 
 > 21 May 2026
 
 ### Fixes
 
+- fix: update CDN version to 4.4.2 in README (hitesh-shetty-cstk - [11bf951](https://github.com/contentstack/live-preview-sdk/commit/11bf9511a5deb7fb009ba9c01310504755a5f17c))
 - fix(hover): guard generateCursor to fire only on new element hover (Hitesh Shetty - [#590](https://github.com/contentstack/live-preview-sdk/pull/590))
 - fix(VB-1541): hide field extension and comment icons on update-restricted fields (Sahil Chalke - [#589](https://github.com/contentstack/live-preview-sdk/pull/589))
 - fix(security): bump dompurify from ^3.4.0 to ^3.4.1 (Hitesh Shetty - [#588](https://github.com/contentstack/live-preview-sdk/pull/588))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v4.4.1](https://github.com/contentstack/live-preview-sdk/compare/v4.4.1...v4.4.1)
+## [v4.4.2](https://github.com/contentstack/live-preview-sdk/compare/v4.4.1...v4.4.2)
 
 > 21 May 2026
 
@@ -21,6 +21,7 @@
 
 ### Chores And Housekeeping
 
+- chore: update CHANGELOG for release v4.4.1 and document recent fixes and changes (hitesh-shetty-cstk - [57dc9b8](https://github.com/contentstack/live-preview-sdk/commit/57dc9b89e6aae7805e16b1c088a367d942f57717))
 - chore: update package-lock.json from npm audit fix (hitesh-shetty-cstk - [7686285](https://github.com/contentstack/live-preview-sdk/commit/7686285a4f73af2226051afa38ac8e5f9fb9a143))
 
 ### General Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,35 @@
 # Changelog
 
+## [v4.4.1](https://github.com/contentstack/live-preview-sdk/compare/v4.4.1...v4.4.1)
+
+> 21 May 2026
+
+### Fixes
+
+- fix(hover): guard generateCursor to fire only on new element hover (Hitesh Shetty - [#590](https://github.com/contentstack/live-preview-sdk/pull/590))
+- fix(VB-1541): hide field extension and comment icons on update-restricted fields (Sahil Chalke - [#589](https://github.com/contentstack/live-preview-sdk/pull/589))
+- fix(security): bump dompurify from ^3.4.0 to ^3.4.1 (Hitesh Shetty - [#588](https://github.com/contentstack/live-preview-sdk/pull/588))
+
+### Fixes
+
+- fix(discussions): pull comment highlights after iframe DOM settles (REQUEST_DISCUSSION_HIGHLIGHTS) (Karan Gandhi - [f03cee9](https://github.com/contentstack/live-preview-sdk/commit/f03cee9e9b24d1f9ab41be25b392367e03c72355))
+- fix: debounce (Karan Gandhi - [ab5941f](https://github.com/contentstack/live-preview-sdk/commit/ab5941f359423620d3a9a171e2921b42b5d1a582))
+- fix(toolbar): re-check DOM guard after async gap in appendFieldToolbar (hitesh-shetty-cstk - [7a94fbc](https://github.com/contentstack/live-preview-sdk/commit/7a94fbcf9fb283c30cb7571ede8fc093a628d43f))
+- fix: test fixes (Karan Gandhi - [b9fb2bb](https://github.com/contentstack/live-preview-sdk/commit/b9fb2bba20ed038114455ca7378e597793d46238))
+- fix: update ws package version to 8.20.1 and add license information (hitesh-shetty-cstk - [677c505](https://github.com/contentstack/live-preview-sdk/commit/677c5058407dcab655b7dd1cc188170241bd742c))
+- fix: comment (Karan Gandhi - [be274f1](https://github.com/contentstack/live-preview-sdk/commit/be274f1750ed33fef37ea5dbfdc7ce089dbacb1d))
+
+### Chores And Housekeeping
+
+- chore: update package-lock.json from npm audit fix (hitesh-shetty-cstk - [7686285](https://github.com/contentstack/live-preview-sdk/commit/7686285a4f73af2226051afa38ac8e5f9fb9a143))
+
+### General Changes
+
+- Merge pull request #583 from contentstack/fix/discussion-comment-variant-cslp-highlight (Karan Bhavesh Gandhi - [76f205f](https://github.com/contentstack/live-preview-sdk/commit/76f205f200429c8d5a14bec72c5eebdd869a8c0b))
+
 ## [v4.4.1](https://github.com/contentstack/live-preview-sdk/compare/v4.4.0...v4.4.1)
 
-> 28 April 2026
+> 4 May 2026
 
 ### New Features
 
@@ -15,6 +42,7 @@
 
 ### General Changes
 
+- release: 4.4.1 (Hitesh Shetty - [#587](https://github.com/contentstack/live-preview-sdk/pull/587))
 - Fix 20 april snyk fixes 2 develop v4 sync (Aditya Pachauri - [#585](https://github.com/contentstack/live-preview-sdk/pull/585))
 - Vp 1721 fix known issues (Kirtesh Suthar - [#581](https://github.com/contentstack/live-preview-sdk/pull/581))
 - Vp 444 stag sync 2 (Aditya Pachauri - [#562](https://github.com/contentstack/live-preview-sdk/pull/562))
@@ -37,12 +65,16 @@
 - chore: update uuid to version 14.0.0 and add vite override (Kirtesh Suthar - [ece4aef](https://github.com/contentstack/live-preview-sdk/commit/ece4aefce7dc6a996d432853791942980db13ccb))
 - chore: audit fix (Karan Gandhi - [48e0c35](https://github.com/contentstack/live-preview-sdk/commit/48e0c35672caa4f54204003de6422830fa1379de))
 - chore: lodash bump (Kirtesh Suthar - [c340241](https://github.com/contentstack/live-preview-sdk/commit/c34024178dcd5522399364fd75d1b5f33f58c35d))
-- chore: lodash-es version upgrade (csAyushDubey - [f96d848](https://github.com/contentstack/live-preview-sdk/commit/f96d8485cb97745698ecb55e3f695701f8c271fb))
 - chore: update tsup configuration to ignore legacy build & dts during dev mode (hiteshshetty-dev - [db0fa6a](https://github.com/contentstack/live-preview-sdk/commit/db0fa6a8d289f22a3dc6fd2ee745b9ae60b85d0f))
 - chore: update doc for dev build mode (hiteshshetty-dev - [45d85f4](https://github.com/contentstack/live-preview-sdk/commit/45d85f4107dd6bbaefdf771ae50ff08068f925ea))
 - chore: upgrade tsup to latest version (hiteshshetty-dev - [52665c4](https://github.com/contentstack/live-preview-sdk/commit/52665c47ba54ccfeac31ca109789ff9f0a8e80e6))
-- chore: make husky pre-push hook executable (Kirtesh Suthar - [2cd613c](https://github.com/contentstack/live-preview-sdk/commit/2cd613c28ee24855da2b1fc3914b07d0fb526713))
 - chore: version bump (csAyushDubey - [2103266](https://github.com/contentstack/live-preview-sdk/commit/2103266fed8763285f5ea8e82a429a3b40015600))
+- chore: make husky pre-push hook executable (Kirtesh Suthar - [2cd613c](https://github.com/contentstack/live-preview-sdk/commit/2cd613c28ee24855da2b1fc3914b07d0fb526713))
+- chore: lodash-es version upgrade (csAyushDubey - [f96d848](https://github.com/contentstack/live-preview-sdk/commit/f96d8485cb97745698ecb55e3f695701f8c271fb))
+
+### Documentation Changes
+
+- docs: update CDN version reference to 4.4.1 in README (hitesh-shetty-cstk - [e5e0106](https://github.com/contentstack/live-preview-sdk/commit/e5e010658633a5bce7ed8721c453fb87b28d513a))
 
 ### Changes to Test Assests
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ npm install @contentstack/live-preview-utils
 
 ### Load from a CDN (advanced)
 
-Pin the version to match your app (update `4.4.1` when you upgrade):
+Pin the version to match your app (update `4.4.2` when you upgrade):
 
 ```html
 <script type="module" crossorigin="anonymous">
-  import ContentstackLivePreview from "https://esm.sh/@contentstack/live-preview-utils@4.4.1";
+  import ContentstackLivePreview from "https://esm.sh/@contentstack/live-preview-utils@4.4.2";
 
   ContentstackLivePreview.init({
     stackDetails: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "classnames": "^2.5.1",
                 "dayjs": "^1.11.13",
                 "deepsignal": "^1.5.0",
-                "dompurify": "^3.4.0",
+                "dompurify": "^3.4.1",
                 "get-xpath": "^3.2.0",
                 "goober": "^2.1.16",
                 "lodash-es": "^4.18.1",
@@ -3681,9 +3681,9 @@
             "dev": true
         },
         "node_modules/dompurify": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+            "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,7 +709,6 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -732,7 +731,6 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1517,7 +1515,6 @@
             "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.0.0.tgz",
             "integrity": "sha512-wzx6YEXw2a+vKdE+p+XlIGsmH2bDjJzzevirtshT9ixoNIV2WJg83kG+QErPHs/ZkeR+MsqgRIFB6x22fDVRlg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@preact/signals-core": "^1.7.0"
             },
@@ -2107,7 +2104,6 @@
             "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.19.0"
             }
@@ -2129,7 +2125,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
             "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -2520,7 +2515,6 @@
             "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
                 "@vitest/utils": "4.1.5",
@@ -2650,7 +2644,6 @@
             "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/utils": "4.1.5",
                 "fflate": "^0.8.2",
@@ -2688,7 +2681,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3331,7 +3323,6 @@
             "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -3419,8 +3410,7 @@
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "peer": true
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/dargs": {
             "version": "8.1.0",
@@ -3956,7 +3946,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -4046,7 +4035,6 @@
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4361,9 +4349,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -5684,7 +5672,6 @@
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
             "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.1.0",
                 "data-urls": "^5.0.0",
@@ -6735,7 +6722,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -6750,7 +6736,6 @@
             "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
             "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -7910,7 +7895,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8203,7 +8187,6 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -8356,7 +8339,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
             "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8421,7 +8403,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.22.0.tgz",
             "integrity": "sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.22.0",
                 "@typescript-eslint/types": "8.22.0",
@@ -8644,7 +8625,6 @@
             "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -8738,7 +8718,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8752,7 +8731,6 @@
             "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.5",
                 "@vitest/mocker": "4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@contentstack/live-preview-utils",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@contentstack/live-preview-utils",
-            "version": "4.4.1",
+            "version": "4.4.2",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9102,10 +9102,11 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "classnames": "^2.5.1",
         "dayjs": "^1.11.13",
         "deepsignal": "^1.5.0",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.1",
         "get-xpath": "^3.2.0",
         "goober": "^2.1.16",
         "lodash-es": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@contentstack/live-preview-utils",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "description": "Contentstack provides the Live Preview SDK to establish a communication channel between the various Contentstack SDKs and your website, transmitting  live changes to the preview pane.",
     "type": "module",
     "types": "dist/legacy/index.d.ts",

--- a/src/visualBuilder/components/FieldToolbar.tsx
+++ b/src/visualBuilder/components/FieldToolbar.tsx
@@ -563,7 +563,7 @@ function FieldToolbarComponent(
                                 {isModalEditable ? editButton : null}
                                 {isReplaceAllowed ? replaceButton : null}
                                 {formButton}
-                                {fieldSchema ? (
+                                {fieldSchema && !disableFieldActions ? (
                                     <CommentIcon
                                         fieldMetadata={fieldMetadata}
                                         fieldSchema={fieldSchema}
@@ -575,16 +575,18 @@ function FieldToolbarComponent(
                             </>
                         )}
 
-                        <FieldLocationIcon
-                            fieldLocationData={fieldLocationData}
-                            multipleFieldToolbarButtonClasses={
-                                multipleFieldToolbarButtonClasses
-                            }
-                            handleMoreIconClick={handleMoreIconClick}
-                            moreButtonRef={moreButtonRef}
-                            toolbarRef={toolbarRef}
-                            domEditStack={domEditStack}
-                        />
+                        {!disableFieldActions && (
+                            <FieldLocationIcon
+                                fieldLocationData={fieldLocationData}
+                                multipleFieldToolbarButtonClasses={
+                                    multipleFieldToolbarButtonClasses
+                                }
+                                handleMoreIconClick={handleMoreIconClick}
+                                moreButtonRef={moreButtonRef}
+                                toolbarRef={toolbarRef}
+                                domEditStack={domEditStack}
+                            />
+                        )}
                     </>
                 </div>
             </div>

--- a/src/visualBuilder/components/__test__/fieldToolbar.test.tsx
+++ b/src/visualBuilder/components/__test__/fieldToolbar.test.tsx
@@ -33,7 +33,13 @@ vi.mock("../../utils/instanceHandlers", () => ({
 
 //CommentIcon testcases are covered seperatly
 vi.mock("../CommentIcon", () => ({
-    default: vi.fn(() => <div>Comment Icon</div>),
+    default: vi.fn(() => <div data-testid="vb-comment-icon">Comment Icon</div>),
+}));
+
+vi.mock("../FieldLocationIcon", () => ({
+    FieldLocationIcon: vi.fn(() => (
+        <div data-testid="vb-field-location-icon">Field Location Icon</div>
+    )),
 }));
 
 vi.mock("../../utils/visualBuilderPostMessage", () => {
@@ -271,6 +277,82 @@ describe("FieldToolbarComponent", () => {
             { timeout: 1000 }
         );
         expect(icon).toBeInTheDocument();
+    });
+
+    describe("CommentIcon and FieldLocationIcon visibility on restricted fields", () => {
+        const wholeMultiMetadata: CslpData = {
+            ...mockMultipleFieldMetadata,
+            fieldPathWithIndex: "group.link",
+            instance: { fieldPathWithIndex: "group.link" },
+        };
+
+        test("renders CommentIcon and FieldLocationIcon when field is not disabled", async () => {
+            vi.mocked(isFieldDisabled).mockReturnValue({
+                isDisabled: false,
+                reason: "" as any,
+            });
+
+            const { container } = render(
+                <FieldToolbarComponent
+                    eventDetails={{
+                        ...mockEventDetails,
+                        fieldMetadata: wholeMultiMetadata,
+                    }}
+                    hideOverlay={vi.fn()}
+                />
+            );
+
+            await act(async () => {
+                await new Promise((r) => setTimeout(r, 0));
+            });
+
+            expect(
+                await findByTestId(
+                    container,
+                    "vb-comment-icon",
+                    {},
+                    { timeout: 1000 }
+                )
+            ).toBeInTheDocument();
+            expect(
+                container.querySelector('[data-testid="vb-field-location-icon"]')
+            ).toBeInTheDocument();
+        });
+
+        test("hides CommentIcon and FieldLocationIcon when field is disabled (update restrict)", async () => {
+            vi.mocked(isFieldDisabled).mockReturnValue({
+                isDisabled: true,
+                reason: "You have only read access to this field" as any,
+            });
+
+            const { container } = render(
+                <FieldToolbarComponent
+                    eventDetails={{
+                        ...mockEventDetails,
+                        fieldMetadata: wholeMultiMetadata,
+                    }}
+                    hideOverlay={vi.fn()}
+                />
+            );
+
+            await act(async () => {
+                await new Promise((r) => setTimeout(r, 0));
+            });
+
+            await findByTestId(
+                container,
+                "visual-builder__focused-toolbar__multiple-field-toolbar",
+                {},
+                { timeout: 1000 }
+            );
+
+            expect(
+                container.querySelector('[data-testid="vb-comment-icon"]')
+            ).not.toBeInTheDocument();
+            expect(
+                container.querySelector('[data-testid="vb-field-location-icon"]')
+            ).not.toBeInTheDocument();
+        });
     });
 
     describe("'Replace button' visibility for multiple file fields", () => {

--- a/src/visualBuilder/eventManager/__test__/useVariantsPostMessageEvent.spec.ts
+++ b/src/visualBuilder/eventManager/__test__/useVariantsPostMessageEvent.spec.ts
@@ -669,4 +669,62 @@ describe("useVariantFieldsPostMessageEvent SSR handling", () => {
         expect(mockQuerySelectorAll).not.toHaveBeenCalled();
         expect(updateVariantClasses).not.toHaveBeenCalled();
     });
+
+    it("sends REQUEST_DISCUSSION_HIGHLIGHTS immediately when isSSR is true and variant is provided", () => {
+        useVariantFieldsPostMessageEvent({ isSSR: true });
+
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.GET_VARIANT_ID
+        );
+        const handler = call ? call[1] : null;
+
+        vi.clearAllMocks();
+        handler!({ data: { variant: "variant-123" } });
+
+        // SSR DOM is already in its final state — the observer would never
+        // fire, so we must ask the visual editor for a fresh highlight list.
+        expect(mockVisualBuilderPostMessage.send).toHaveBeenCalledWith(
+            VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
+        );
+    });
+
+    it("sends REQUEST_DISCUSSION_HIGHLIGHTS immediately when isSSR is true even if variant is null", () => {
+        useVariantFieldsPostMessageEvent({ isSSR: true });
+
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.GET_VARIANT_ID
+        );
+        const handler = call ? call[1] : null;
+
+        vi.clearAllMocks();
+        handler!({ data: { variant: null } });
+
+        // Switching back to base is still a CSLP-relevant change — VB needs to
+        // re-compute and re-send highlights against the new (base) CSLPs.
+        expect(mockVisualBuilderPostMessage.send).toHaveBeenCalledWith(
+            VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
+        );
+    });
+
+    it("does not send REQUEST_DISCUSSION_HIGHLIGHTS directly when isSSR is false (observer handles it)", () => {
+        useVariantFieldsPostMessageEvent({ isSSR: false });
+
+        const call = mockVisualBuilderPostMessage.on.mock.calls.find(
+            (call: any[]) =>
+                call[0] === VisualBuilderPostMessageEvents.GET_VARIANT_ID
+        );
+        const handler = call ? call[1] : null;
+
+        vi.clearAllMocks();
+        handler!({ data: { variant: "variant-123" } });
+
+        // For CSR apps the event is emitted by the MutationObserver inside
+        // updateVariantClasses, not synchronously from the handler.
+        expect(mockVisualBuilderPostMessage.send).not.toHaveBeenCalledWith(
+            VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
+        );
+        expect(updateVariantClasses).toHaveBeenCalled();
+    });
 });

--- a/src/visualBuilder/eventManager/__test__/useVariantsPostMessageEvent.spec.ts
+++ b/src/visualBuilder/eventManager/__test__/useVariantsPostMessageEvent.spec.ts
@@ -708,7 +708,7 @@ describe("useVariantFieldsPostMessageEvent SSR handling", () => {
         );
     });
 
-    it("does not send REQUEST_DISCUSSION_HIGHLIGHTS directly when isSSR is false (observer handles it)", () => {
+    it("sends REQUEST_DISCUSSION_HIGHLIGHTS and calls updateVariantClasses when isSSR is false", () => {
         useVariantFieldsPostMessageEvent({ isSSR: false });
 
         const call = mockVisualBuilderPostMessage.on.mock.calls.find(
@@ -720,9 +720,10 @@ describe("useVariantFieldsPostMessageEvent SSR handling", () => {
         vi.clearAllMocks();
         handler!({ data: { variant: "variant-123" } });
 
-        // For CSR apps the event is emitted by the MutationObserver inside
-        // updateVariantClasses, not synchronously from the handler.
-        expect(mockVisualBuilderPostMessage.send).not.toHaveBeenCalledWith(
+        // CSR path: handler triggers updateVariantClasses (observer settles
+        // CSLPs) and also sends the request as a safety net so VB recomputes
+        // highlights against the new variant.
+        expect(mockVisualBuilderPostMessage.send).toHaveBeenCalledWith(
             VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
         );
         expect(updateVariantClasses).toHaveBeenCalled();

--- a/src/visualBuilder/eventManager/useRecalculateVariantDataCSLPValues.ts
+++ b/src/visualBuilder/eventManager/useRecalculateVariantDataCSLPValues.ts
@@ -7,12 +7,17 @@ import { isValidCslp } from "../../cslp/cslpdata";
 import { setHighlightVariantFields } from "./useVariantsPostMessageEvent";
 import visualBuilderPostMessage from "../utils/visualBuilderPostMessage";
 import { VisualBuilderPostMessageEvents } from "../utils/types/postMessage.types";
+import { debounce } from "lodash-es";
 
 const VARIANT_UPDATE_DELAY_MS: Readonly<number> = 8000;
-// Debounce window after the last observed mutation before asking the visual
-// editor to re-send discussion highlights. Short enough to feel responsive;
-// long enough to coalesce a burst of mutations into a single request.
-const DISCUSSION_HIGHLIGHTS_DEBOUNCE_MS: Readonly<number> = 200;
+
+// Coalesce a burst of data-cslp mutations into a single request to the
+// visual editor.
+const requestDiscussionHighlights = debounce(() => {
+    visualBuilderPostMessage?.send(
+        VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
+    );
+}, 200);
 
 type OnAudienceModeVariantPatchUpdate = {
     highlightVariantFields: boolean;
@@ -37,21 +42,6 @@ export function updateVariantClasses(): void {
     const highlightVariantFields = VisualBuilder.VisualBuilderGlobalState.value.highlightVariantFields;
     const variant = VisualBuilder.VisualBuilderGlobalState.value.variant;
     const observers: MutationObserver[] = [];
-
-    // Ask the visual editor to re-send discussion highlights once the current
-    // burst of data-cslp mutations has settled. The VB owns the field-path list
-    // (it can be per-variant) so the iframe cannot re-mount comment icons on
-    // its own — it can only request a refresh.
-    let highlightsRequestTimer: ReturnType<typeof setTimeout> | null = null;
-    const requestDiscussionHighlights = () => {
-        if (highlightsRequestTimer !== null) clearTimeout(highlightsRequestTimer);
-        highlightsRequestTimer = setTimeout(() => {
-            highlightsRequestTimer = null;
-            visualBuilderPostMessage?.send(
-                VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
-            );
-        }, DISCUSSION_HIGHLIGHTS_DEBOUNCE_MS);
-    };
 
     // Helper function to update element classes
     const updateElementClasses = (

--- a/src/visualBuilder/eventManager/useRecalculateVariantDataCSLPValues.ts
+++ b/src/visualBuilder/eventManager/useRecalculateVariantDataCSLPValues.ts
@@ -5,8 +5,14 @@ import { DATA_CSLP_ATTR_SELECTOR } from "../utils/constants";
 import { visualBuilderStyles } from "../visualBuilder.style";
 import { isValidCslp } from "../../cslp/cslpdata";
 import { setHighlightVariantFields } from "./useVariantsPostMessageEvent";
+import visualBuilderPostMessage from "../utils/visualBuilderPostMessage";
+import { VisualBuilderPostMessageEvents } from "../utils/types/postMessage.types";
 
 const VARIANT_UPDATE_DELAY_MS: Readonly<number> = 8000;
+// Debounce window after the last observed mutation before asking the visual
+// editor to re-send discussion highlights. Short enough to feel responsive;
+// long enough to coalesce a burst of mutations into a single request.
+const DISCUSSION_HIGHLIGHTS_DEBOUNCE_MS: Readonly<number> = 200;
 
 type OnAudienceModeVariantPatchUpdate = {
     highlightVariantFields: boolean;
@@ -31,6 +37,21 @@ export function updateVariantClasses(): void {
     const highlightVariantFields = VisualBuilder.VisualBuilderGlobalState.value.highlightVariantFields;
     const variant = VisualBuilder.VisualBuilderGlobalState.value.variant;
     const observers: MutationObserver[] = [];
+
+    // Ask the visual editor to re-send discussion highlights once the current
+    // burst of data-cslp mutations has settled. The VB owns the field-path list
+    // (it can be per-variant) so the iframe cannot re-mount comment icons on
+    // its own — it can only request a refresh.
+    let highlightsRequestTimer: ReturnType<typeof setTimeout> | null = null;
+    const requestDiscussionHighlights = () => {
+        if (highlightsRequestTimer !== null) clearTimeout(highlightsRequestTimer);
+        highlightsRequestTimer = setTimeout(() => {
+            highlightsRequestTimer = null;
+            visualBuilderPostMessage?.send(
+                VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
+            );
+        }, DISCUSSION_HIGHLIGHTS_DEBOUNCE_MS);
+    };
 
     // Helper function to update element classes
     const updateElementClasses = (
@@ -156,6 +177,7 @@ export function updateVariantClasses(): void {
                         DATA_CSLP_ATTR_SELECTOR
                     );
                     updateElementClasses(element, dataCslp || "", observer);
+                    requestDiscussionHighlights();
                 }
             });
         });

--- a/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
+++ b/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
@@ -167,18 +167,12 @@ export function useVariantFieldsPostMessageEvent({ isSSR }: { isSSR: boolean }):
                 if (selectedVariant) {
                     addVariantFieldClass(selectedVariant);
                 }
-                // SSR DOM is already in its final state (no async re-render) —
-                // the MutationObserver in updateVariantClasses will never fire,
-                // so ask the visual editor to re-send discussion highlights now
-                // that the classes are applied against the final CSLP values.
+                // SSR DOM is final; observer never fires, request directly.
                 visualBuilderPostMessage?.send(
                     VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
                 );
             } else {
-                // For CSR apps the framework re-renders asynchronously after
-                // receiving the new variant, mutating data-cslp attributes.
-                // updateVariantClasses installs a MutationObserver that emits
-                // REQUEST_DISCUSSION_HIGHLIGHTS once those mutations settle.
+                // CSR: observer in updateVariantClasses requests on settle.
                 updateVariantClasses();
             }
         }

--- a/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
+++ b/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
@@ -174,6 +174,9 @@ export function useVariantFieldsPostMessageEvent({ isSSR }: { isSSR: boolean }):
             } else {
                 // CSR: observer in updateVariantClasses requests on settle.
                 updateVariantClasses();
+                visualBuilderPostMessage?.send(
+                    VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
+                );
             }
         }
     );

--- a/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
+++ b/src/visualBuilder/eventManager/useVariantsPostMessageEvent.ts
@@ -167,8 +167,18 @@ export function useVariantFieldsPostMessageEvent({ isSSR }: { isSSR: boolean }):
                 if (selectedVariant) {
                     addVariantFieldClass(selectedVariant);
                 }
+                // SSR DOM is already in its final state (no async re-render) —
+                // the MutationObserver in updateVariantClasses will never fire,
+                // so ask the visual editor to re-send discussion highlights now
+                // that the classes are applied against the final CSLP values.
+                visualBuilderPostMessage?.send(
+                    VisualBuilderPostMessageEvents.REQUEST_DISCUSSION_HIGHLIGHTS
+                );
             } else {
-                // recalculate and apply classes
+                // For CSR apps the framework re-renders asynchronously after
+                // receiving the new variant, mutating data-cslp attributes.
+                // updateVariantClasses installs a MutationObserver that emits
+                // REQUEST_DISCUSSION_HIGHLIGHTS once those mutations settle.
                 updateVariantClasses();
             }
         }

--- a/src/visualBuilder/generators/__test__/generateHighlightedComment.test.ts
+++ b/src/visualBuilder/generators/__test__/generateHighlightedComment.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+    updateHighlightedCommentIconPosition,
+    removeAllHighlightedCommentIcons,
+} from "../generateHighlightedComment";
+
+describe("updateHighlightedCommentIconPosition", () => {
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        container.className = "visual-builder__container";
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    const makeIcon = (fieldPath: string): HTMLDivElement => {
+        const icon = document.createElement("div");
+        icon.className = "highlighted-comment collab-icon";
+        icon.setAttribute("field-path", fieldPath);
+        icon.style.position = "fixed";
+        icon.style.top = "100px";
+        icon.style.left = "200px";
+        container.appendChild(icon);
+        return icon;
+    };
+
+    const makeTarget = (cslpValue: string): HTMLDivElement => {
+        const el = document.createElement("div");
+        el.setAttribute("data-cslp", cslpValue);
+        container.appendChild(el);
+        return el;
+    };
+
+    it("keeps an icon whose target element is still present", () => {
+        const cslp = "content.entry.en-us.field";
+        makeTarget(cslp);
+        makeIcon(cslp);
+
+        updateHighlightedCommentIconPosition();
+
+        expect(
+            document.querySelector(`.highlighted-comment[field-path="${cslp}"]`),
+        ).not.toBeNull();
+    });
+
+    it("removes an orphaned icon when its target element is no longer found", () => {
+        // Stale CSLP with no matching element — simulates the element having
+        // been mutated to a variant CSLP value.
+        const staleCslp = "content.entry.en-us.old_field";
+        makeIcon(staleCslp);
+
+        updateHighlightedCommentIconPosition();
+
+        expect(
+            document.querySelector(`.highlighted-comment[field-path="${staleCslp}"]`),
+        ).toBeNull();
+    });
+
+    it("removes only orphaned icons and keeps valid ones", () => {
+        const validCslp = "content.entry.en-us.valid";
+        const staleCslp = "content.entry.en-us.stale";
+
+        makeTarget(validCslp);
+        makeIcon(validCslp);
+        makeIcon(staleCslp);
+
+        updateHighlightedCommentIconPosition();
+
+        expect(
+            document.querySelector(`.highlighted-comment[field-path="${validCslp}"]`),
+        ).not.toBeNull();
+        expect(
+            document.querySelector(`.highlighted-comment[field-path="${staleCslp}"]`),
+        ).toBeNull();
+    });
+
+    it("does not throw when there are no icons", () => {
+        expect(() => updateHighlightedCommentIconPosition()).not.toThrow();
+    });
+});
+
+describe("removeAllHighlightedCommentIcons", () => {
+    it("removes every .highlighted-comment element", () => {
+        ["a", "b", "c"].forEach((cslp) => {
+            const icon = document.createElement("div");
+            icon.className = "highlighted-comment collab-icon";
+            icon.setAttribute("field-path", cslp);
+            document.body.appendChild(icon);
+        });
+
+        expect(document.querySelectorAll(".highlighted-comment").length).toBe(3);
+
+        removeAllHighlightedCommentIcons();
+
+        expect(document.querySelectorAll(".highlighted-comment").length).toBe(0);
+    });
+});

--- a/src/visualBuilder/generators/generateHighlightedComment.tsx
+++ b/src/visualBuilder/generators/generateHighlightedComment.tsx
@@ -96,10 +96,7 @@ export function updateHighlightedCommentIconPosition() {
                     icon.style.top = `${top - highlighCommentOffset}px`; // Adjust based on the target element's top
                     icon.style.left = `${left - highlighCommentOffset}px`; // Adjust based on the target element's left
                 } else {
-                    // Target element is gone (e.g. data-cslp mutated after a
-                    // variant switch). Remove the orphaned icon instead of
-                    // silently leaving it drifted — the visual editor will
-                    // re-mount a fresh set via REQUEST_DISCUSSION_HIGHLIGHTS.
+                    // Target gone — drop the orphan icon.
                     icon.remove();
                 }
             }

--- a/src/visualBuilder/generators/generateHighlightedComment.tsx
+++ b/src/visualBuilder/generators/generateHighlightedComment.tsx
@@ -95,6 +95,12 @@ export function updateHighlightedCommentIconPosition() {
                     // Update the position of the icon container
                     icon.style.top = `${top - highlighCommentOffset}px`; // Adjust based on the target element's top
                     icon.style.left = `${left - highlighCommentOffset}px`; // Adjust based on the target element's left
+                } else {
+                    // Target element is gone (e.g. data-cslp mutated after a
+                    // variant switch). Remove the orphaned icon instead of
+                    // silently leaving it drifted — the visual editor will
+                    // re-mount a fresh set via REQUEST_DISCUSSION_HIGHLIGHTS.
+                    icon.remove();
                 }
             }
         }

--- a/src/visualBuilder/generators/generateToolbar.tsx
+++ b/src/visualBuilder/generators/generateToolbar.tsx
@@ -45,11 +45,8 @@ export async function appendFieldToolbar(
     }
 ): Promise<void> {
     const { isHover } = options || {};
-    if (
-        focusedToolbarElement.querySelector(
-            ".visual-builder__focused-toolbar__multiple-field-toolbar"
-        ) && !isHover
-    )
+    const toolbarSelector = ".visual-builder__focused-toolbar__multiple-field-toolbar";
+    if (focusedToolbarElement.querySelector(toolbarSelector) && !isHover)
         return;
     const { acl: entryPermissions, workflowStage: entryWorkflowStageDetails, resolvedVariantPermissions } =
         await fetchEntryPermissionsAndStageDetails({
@@ -59,6 +56,10 @@ export async function appendFieldToolbar(
             variantUid: eventDetails.fieldMetadata.variant,
             fieldPathWithIndex: eventDetails.fieldMetadata.fieldPathWithIndex,
         });
+    // Re-check after the async gap: a concurrent call (e.g. reEvaluate) may have
+    // already appended while fetchEntryPermissionsAndStageDetails was in-flight.
+    if (focusedToolbarElement.querySelector(toolbarSelector) && !isHover)
+        return;
     const wrapper = document.createDocumentFragment();
     render(
         <FieldToolbarComponent

--- a/src/visualBuilder/listeners/__test__/mouseHover.test.ts
+++ b/src/visualBuilder/listeners/__test__/mouseHover.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import handleMouseHover from "../mouseHover";
+import { VisualBuilder } from "../../index";
+import * as fetchEntryPermissionsModule from "../../utils/fetchEntryPermissionsAndStageDetails";
+import { FieldSchemaMap } from "../../utils/fieldSchemaMap";
+
+vi.mock("lodash-es", async () => ({
+    ...(await import("lodash-es")),
+    throttle: vi.fn((fn) => fn),
+    debounce: vi.fn((fn) => fn),
+}));
+
+vi.mock("../../utils/fetchEntryPermissionsAndStageDetails", () => ({
+    fetchEntryPermissionsAndStageDetails: vi.fn().mockResolvedValue({
+        acl: { update: { create: true, read: true, update: true, delete: true, publish: true } },
+        workflowStage: { stage: undefined, permissions: { entry: { update: true } } },
+        resolvedVariantPermissions: { update: true },
+    }),
+}));
+
+vi.mock("../../utils/fieldSchemaMap", () => ({
+    FieldSchemaMap: {
+        getFieldSchema: vi.fn().mockResolvedValue({ data_type: "text", field_metadata: {} }),
+        hasFieldSchema: vi.fn().mockReturnValue(true),
+        setFieldSchema: vi.fn(),
+    },
+}));
+
+vi.mock("../../generators/generateCustomCursor", () => ({
+    generateCustomCursor: vi.fn(),
+}));
+
+vi.mock("../../generators/generateHoverOutline.tsx", () => ({
+    addHoverOutline: vi.fn(),
+}));
+
+vi.mock("../../utils/getCsDataOfElement", () => ({
+    getCsDataOfElement: vi.fn(),
+}));
+
+vi.mock("../../utils/multipleElementAddButton", () => ({
+    removeAddInstanceButtons: vi.fn(),
+}));
+
+vi.mock("../../generators/generateToolbar", () => ({
+    appendFieldPathDropdown: vi.fn(),
+}));
+
+vi.mock("../../index", () => ({
+    VisualBuilder: {
+        VisualBuilderGlobalState: {
+            value: {
+                previousSelectedEditableDOM: null,
+                previousHoveredTargetDOM: null,
+                isFocussed: false,
+            },
+        },
+    },
+}));
+
+vi.mock("../../configManager/configManager", () => ({
+    default: {
+        get: vi.fn().mockReturnValue({
+            collab: { enable: false, isFeedbackMode: false, pauseFeedback: false },
+        }),
+    },
+}));
+
+vi.mock("../../visualBuilder.style", () => ({
+    visualBuilderStyles: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../generators/generateThread", () => ({
+    isCollabThread: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../../utils/isFieldDisabled", () => ({
+    isFieldDisabled: vi.fn().mockReturnValue({ isDisabled: false }),
+}));
+
+vi.mock("../../utils/getFieldType", () => ({
+    getFieldType: vi.fn().mockReturnValue("singleline"),
+}));
+
+const { getCsDataOfElement } = await import("../../utils/getCsDataOfElement");
+const mockedGetCsDataOfElement = vi.mocked(getCsDataOfElement);
+const mockedFetchEntryPermissions = vi.mocked(
+    fetchEntryPermissionsModule.fetchEntryPermissionsAndStageDetails
+);
+
+function makeElement(): HTMLElement {
+    const el = document.createElement("div");
+    el.setAttribute("data-cslp", "all_fields.entry1.en-us.title");
+    document.body.appendChild(el);
+    return el;
+}
+
+function makeEventDetails(editableElement: HTMLElement) {
+    return {
+        editableElement,
+        fieldMetadata: {
+            entry_uid: "entry1",
+            content_type_uid: "all_fields",
+            locale: "en-us",
+            fieldPath: "title",
+            fieldPathWithIndex: "title",
+            variant: undefined,
+        },
+    };
+}
+
+function makeParams(editableElement: HTMLElement, customCursor: HTMLDivElement) {
+    return {
+        event: new MouseEvent("mousemove"),
+        overlayWrapper: document.createElement("div"),
+        visualBuilderContainer: document.createElement("div"),
+        focusedToolbar: document.createElement("div"),
+        resizeObserver: new ResizeObserver(() => {}),
+        customCursor,
+    };
+}
+
+describe("mouseHover — generateCursor same-element guard", () => {
+    let editableElement: HTMLElement;
+    let customCursor: HTMLDivElement;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        document.body.innerHTML = "";
+
+        editableElement = makeElement();
+        customCursor = document.createElement("div");
+
+        VisualBuilder.VisualBuilderGlobalState.value.previousHoveredTargetDOM = null;
+        VisualBuilder.VisualBuilderGlobalState.value.previousSelectedEditableDOM = null;
+        VisualBuilder.VisualBuilderGlobalState.value.isFocussed = false;
+    });
+
+    // On a new element, both generateCursor and addOutline call fetchEntryPermissionsAndStageDetails
+    // — so the delta per first-hover is 2.
+    it("calls fetchEntryPermissionsAndStageDetails from both generateCursor and addOutline on new element hover", async () => {
+        mockedGetCsDataOfElement.mockReturnValue(makeEventDetails(editableElement) as any);
+
+        const before = mockedFetchEntryPermissions.mock.calls.length;
+        await handleMouseHover(makeParams(editableElement, customCursor));
+        const delta = mockedFetchEntryPermissions.mock.calls.length - before;
+
+        // generateCursor (1) + addOutline (1) = 2
+        expect(delta).toBe(2);
+    });
+
+    // On the same element, the guard skips generateCursor — only addOutline fires.
+    // Delta drops from 2 to 1, proving the guard is active.
+    it("skips generateCursor (reduces call delta to 1) when hovering the same element again", async () => {
+        mockedGetCsDataOfElement.mockReturnValue(makeEventDetails(editableElement) as any);
+
+        // First hover over new element — delta = 2 (generateCursor + addOutline)
+        await handleMouseHover(makeParams(editableElement, customCursor));
+
+        const afterFirst = mockedFetchEntryPermissions.mock.calls.length;
+
+        // Second hover over the SAME element — generateCursor is guarded, only addOutline fires
+        await handleMouseHover(makeParams(editableElement, customCursor));
+
+        const secondDelta = mockedFetchEntryPermissions.mock.calls.length - afterFirst;
+        expect(secondDelta).toBe(1);
+    });
+
+    // Moving to a different element resets the guard — both generateCursor and addOutline fire again.
+    it("calls both generateCursor and addOutline (delta = 2) when hovering a different element", async () => {
+        mockedGetCsDataOfElement.mockReturnValue(makeEventDetails(editableElement) as any);
+        await handleMouseHover(makeParams(editableElement, customCursor));
+
+        const secondElement = makeElement();
+        mockedGetCsDataOfElement.mockReturnValue(makeEventDetails(secondElement) as any);
+
+        const before = mockedFetchEntryPermissions.mock.calls.length;
+        await handleMouseHover(makeParams(secondElement, customCursor));
+        const delta = mockedFetchEntryPermissions.mock.calls.length - before;
+
+        expect(delta).toBe(2);
+    });
+});

--- a/src/visualBuilder/listeners/mouseHover.ts
+++ b/src/visualBuilder/listeners/mouseHover.ts
@@ -317,11 +317,17 @@ const throttledMouseHover = throttle(async (params: HandleMouseHoverParams) => {
             });
         }
 
-        // we can generate the cursor asynchronously
-        generateCursor({
-            eventDetails,
-            customCursor: params.customCursor,
-        });
+        // only re-generate cursor when moving onto a new element — avoids
+        // firing fetchEntryPermissionsAndStageDetails on every 10ms tick
+        if (
+            VisualBuilder.VisualBuilderGlobalState.value
+                .previousHoveredTargetDOM !== editableElement
+        ) {
+            generateCursor({
+                eventDetails,
+                customCursor: params.customCursor,
+            });
+        }
 
         handleCursorPosition(params.event, params.customCursor);
         showCustomCursor(params.customCursor);

--- a/src/visualBuilder/utils/types/postMessage.types.ts
+++ b/src/visualBuilder/utils/types/postMessage.types.ts
@@ -59,4 +59,5 @@ export enum VisualBuilderPostMessageEvents {
     COLLAB_THREAD_REOPEN = "collab-thread-reopen",
     COLLAB_THREAD_HIGHLIGHT = "collab-thread-highlight",
     TOGGLE_SCROLL = "toggle-scroll",
+    REQUEST_DISCUSSION_HIGHLIGHTS = "request-discussion-highlights",
 }


### PR DESCRIPTION
## Summary

- Merge `develop_v4` → `stage_v4` and promote to `main` for prod release
- Patch version bump `4.4.1 → 4.4.2`
- CHANGELOG updated via `auto-changelog`
- README CDN reference updated to `4.4.2`

## Fixes

- fix(hover): guard `generateCursor` to fire only on new element hover (#590)
- fix(VB-1541): hide field extension and comment icons on update-restricted fields (#589)
- fix(toolbar): re-check DOM guard after async gap in `appendFieldToolbar`
- fix(discussions): pull comment highlights after iframe DOM settles (`REQUEST_DISCUSSION_HIGHLIGHTS`)
- fix(discussions): debounce variant cslp highlight refresh (#583)

## Security

- fix(security): bump `dompurify` from `^3.4.0` → `^3.4.1` (#588)
- chore: bump `ws` to `8.20.1` and update license info
- chore: `npm audit` fix on lockfile

## Chores

- chore: CHANGELOG regenerated for v4.4.2
- chore: README CDN bump to 4.4.2
