### PR TITLE
fix: added changes of new tab init related remaining code

### DIFF
--- a/src/common/__test__/inIframe.test.ts
+++ b/src/common/__test__/inIframe.test.ts
@@ -1,4 +1,7 @@
-import { inIframe } from "../inIframe";
+import { inIframe, isOpeningInNewTab } from "../inIframe";
+import { hasWindow } from "../../utils";
+
+vi.mock("../../utils", () => ({ hasWindow: vi.fn() }));
 
 describe("inIframe", () => {
     let windowSpy: any;
@@ -37,5 +40,41 @@ describe("inIframe", () => {
         });
 
         expect(inIframe()).toBe(true);
+    });
+});
+
+describe("isOpeningInNewTab", () => {
+    let windowSpy: any;
+
+    beforeEach(() => {
+        vi.mocked(hasWindow).mockReturnValue(true);
+        windowSpy = vi.spyOn(window, "window", "get");
+    });
+
+    afterEach(() => {
+        windowSpy.mockRestore();
+        vi.mocked(hasWindow).mockReset();
+    });
+
+    test("should return true when window.opener is truthy", () => {
+        windowSpy.mockReturnValue({ opener: {} });
+        expect(isOpeningInNewTab()).toBe(true);
+    });
+
+    test("should return false when window.opener is null", () => {
+        windowSpy.mockReturnValue({ opener: null });
+        expect(isOpeningInNewTab()).toBe(false);
+    });
+
+    test("should return false when hasWindow returns false", () => {
+        vi.mocked(hasWindow).mockReturnValue(false);
+        expect(isOpeningInNewTab()).toBe(false);
+    });
+
+    test("should return false when accessing window throws", () => {
+        windowSpy.mockImplementation(() => {
+            throw new Error("Test error");
+        });
+        expect(isOpeningInNewTab()).toBe(false);
     });
 });

--- a/src/livePreview/eventManager/__test__/postMessageEvent.hooks.test.ts
+++ b/src/livePreview/eventManager/__test__/postMessageEvent.hooks.test.ts
@@ -266,6 +266,26 @@ describe("postMessageEvent.hooks", () => {
                     expect(redirectUrl.searchParams.get("content_type_uid")).toBe("blog");
                     expect(redirectUrl.searchParams.has("entry_uid")).toBe(false);
                 });
+
+                it("should use stackDetails.contentTypeUid and entryUid as fallback when event data omits them", () => {
+                    mockConfig.ssr = true;
+                    mockConfig.stackDetails = { contentTypeUid: "fallback-ct", entryUid: "fallback-entry" };
+                    (Config.get as any).mockReturnValue(mockConfig);
+                    mockWindow.location.href = "https://example.com";
+
+                    const eventData: OnChangeLivePreviewPostMessageEventData = {
+                        hash: "h",
+                    };
+
+                    const callback = mockWindow._eventCallbacks[LIVE_PREVIEW_POST_MESSAGE_EVENTS.ON_CHANGE];
+                    callback({ data: eventData });
+
+                    const redirectUrl = new URL(mockWindow.location.href);
+                    expect(redirectUrl.searchParams.get("live_preview")).toBe("h");
+                    expect(redirectUrl.searchParams.get("content_type_uid")).toBe("fallback-ct");
+                    expect(redirectUrl.searchParams.get("entry_uid")).toBe("fallback-entry");
+                    expect(mockWindow.location.reload).not.toHaveBeenCalled();
+                });
             });
         });
 
@@ -682,5 +702,6 @@ describe("postMessageEvent.hooks", () => {
                 vi.useRealTimers();
             }
         });
+
     });
 });

--- a/src/livePreview/eventManager/postMessageEvent.hooks.ts
+++ b/src/livePreview/eventManager/postMessageEvent.hooks.ts
@@ -78,8 +78,8 @@ export function useOnEntryUpdatePostMessageEvent(): void {
                             window.location.reload();
                         } else {
                             live_preview = event.data.hash;
-                            content_type_uid = event.data.content_type_uid || stackDetails.$contentTypeUid?.toString() || "";
-                            entry_uid = event.data.entry_uid || stackDetails.$entryUid?.toString() || "";
+                            content_type_uid = event.data.content_type_uid || stackDetails.contentTypeUid?.toString() || "";
+                            entry_uid = event.data.entry_uid || stackDetails.entryUid?.toString() || "";
                             // Set missing params and redirect
                             url.searchParams.set("live_preview", live_preview);
                             if (content_type_uid) {
@@ -169,7 +169,11 @@ export function sendInitializeLivePreviewPostMessageEvent(): void {
                 //     "init message did not contain contentTypeUid or entryUid."
                 // );
             }
-            if (Config.get().ssr || isOpeningInTimeline() || isOpeningInNewTab()) {
+            if (
+                Config.get().ssr ||
+                isOpeningInTimeline() ||
+                isOpeningInNewTab()
+            ) {
                 addParamsToUrl();
             }
             Config.set("windowType", windowType);

--- a/src/preview/__test__/contentstack-live-preview-HOC.test.ts
+++ b/src/preview/__test__/contentstack-live-preview-HOC.test.ts
@@ -120,6 +120,19 @@ describe("Live Preview HOC init", () => {
             "You have already initialized the Live Preview SDK. So, any subsequent initialization returns the existing SDK instance."
         );
     });
+
+    test("should not send INIT postMessage when enable is false", () => {
+        if (!livePreviewPostMessage) {
+            throw new Error("livePreviewPostMessage is unavailable");
+        }
+
+        const livePreviewPostMessageSpy = vi.spyOn(livePreviewPostMessage, "send");
+
+        // no await needed — LivePreview constructor runs synchronously when document.readyState is "complete" in jsdom
+        ContentstackLivePreview.init({ enable: false });
+
+        expect(livePreviewPostMessageSpy).not.toHaveBeenCalled();
+    });
 });
 
 describe("Live Preview HOC config", () => {


### PR DESCRIPTION
fix: added changes of new tab init related remaining code

 ## Summary

  Fixes a silent bug in the new-tab SSR redirect path where stackDetails.$contentTypeUid and stackDetails.$entryUid were read — properties that don't exist on IStackDetails. The fallback always produced empty strings, causing the redirect URL to be missing content_type_uid and entry_uid when the ON_CHANGE event data omitted them. Also adds previously absent unit tests for isOpeningInNewTab(), the stackDetails fallback path, and init({ enable: false }).
  
## Changes Made

  - src/livePreview/eventManager/postMessageEvent.hooks.ts: Fix stackDetails.$contentTypeUid → stackDetails.contentTypeUid and stackDetails.$entryUid →
  stackDetails.entryUid in the new-tab SSR redirect branch
  - src/common/__test__/inIframe.test.ts: Add 4 unit tests for isOpeningInNewTab() — opener truthy, opener null, hasWindow() false, window access throws
  - src/livePreview/eventManager/__test__/postMessageEvent.hooks.test.ts: Add test for stackDetails.contentTypeUid/entryUid fallback when ON_CHANGE event data
  omits those fields
  - src/preview/__test__/contentstack-live-preview-HOC.test.ts: Add test verifying no INIT postMessage is sent when init({ enable: false }) is called

## Why These Changes

  IStackDetails defines contentTypeUid and entryUid (no $ prefix). The implementation was reading $contentTypeUid/$entryUid, which are undefined on all real
  instances. This meant any new-tab SSR reload where the event omitted those fields would silently redirect without the required URL params, breaking the
  preview. The test additions close coverage gaps for the surrounding code paths.

