### PR TITLE
VB-1556: Scroll iframe to #anchor on initial load (Visual Builder)

### DIFF
--- a/src/visualBuilder/eventManager/__test__/useScrollToHashAnchor.test.ts
+++ b/src/visualBuilder/eventManager/__test__/useScrollToHashAnchor.test.ts
@@ -1,0 +1,164 @@
+import {
+    vi,
+    describe,
+    it,
+    expect,
+    beforeEach,
+    afterEach,
+} from "vitest";
+import { useScrollToHashAnchor } from "../useScrollToHashAnchor";
+
+const setLocationHash = (hash: string) => {
+    Object.defineProperty(window, "location", {
+        writable: true,
+        value: { ...window.location, hash, href: `http://localhost/${hash}` },
+    });
+};
+
+describe("useScrollToHashAnchor", () => {
+    let scrollSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        scrollSpy = vi.fn();
+        // jsdom doesn't implement scrollIntoView.
+        Element.prototype.scrollIntoView = scrollSpy as unknown as (
+            arg?: boolean | ScrollIntoViewOptions
+        ) => void;
+        setLocationHash("");
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("does nothing when there is no hash", () => {
+        setLocationHash("");
+        const el = document.createElement("div");
+        el.id = "footer";
+        document.body.appendChild(el);
+
+        useScrollToHashAnchor();
+
+        expect(scrollSpy).not.toHaveBeenCalled();
+    });
+
+    it("ignores hash-router URLs starting with #/", () => {
+        setLocationHash("#/dashboard");
+        const el = document.createElement("div");
+        el.id = "dashboard";
+        document.body.appendChild(el);
+
+        useScrollToHashAnchor();
+
+        expect(scrollSpy).not.toHaveBeenCalled();
+    });
+
+    it("ignores hashbang router URLs starting with #!/", () => {
+        setLocationHash("#!/products");
+        const el = document.createElement("div");
+        el.id = "products";
+        document.body.appendChild(el);
+
+        useScrollToHashAnchor();
+
+        expect(scrollSpy).not.toHaveBeenCalled();
+    });
+
+    it("scrolls immediately when the anchor element already exists", () => {
+        setLocationHash("#footer");
+        const el = document.createElement("div");
+        el.id = "footer";
+        document.body.appendChild(el);
+
+        useScrollToHashAnchor();
+
+        expect(scrollSpy).toHaveBeenCalledTimes(1);
+        expect(scrollSpy).toHaveBeenCalledWith({
+            behavior: "smooth",
+            block: "start",
+        });
+    });
+
+    it("waits for the anchor element to appear via MutationObserver", () => {
+        // jsdom's MutationObserver microtask flushing is unreliable in vitest,
+        // so we stub it and trigger the callback manually.
+        let observerCallback: MutationCallback | null = null;
+        const disconnect = vi.fn();
+        const observe = vi.fn();
+        const OriginalMO = global.MutationObserver;
+        class StubMutationObserver {
+            constructor(cb: MutationCallback) {
+                observerCallback = cb;
+            }
+            observe = observe;
+            disconnect = disconnect;
+            takeRecords = () => [];
+        }
+        global.MutationObserver =
+            StubMutationObserver as unknown as typeof MutationObserver;
+
+        try {
+            setLocationHash("#footer");
+            useScrollToHashAnchor();
+
+            expect(scrollSpy).not.toHaveBeenCalled();
+            expect(observe).toHaveBeenCalledTimes(1);
+
+            // Element appears later (SPA hydration), observer fires.
+            const el = document.createElement("div");
+            el.id = "footer";
+            document.body.appendChild(el);
+            observerCallback?.([], {} as MutationObserver);
+
+            expect(scrollSpy).toHaveBeenCalledTimes(1);
+            expect(disconnect).toHaveBeenCalledTimes(1);
+        } finally {
+            global.MutationObserver = OriginalMO;
+        }
+    });
+
+    it("falls back to elements queried by name attribute (legacy anchors)", () => {
+        setLocationHash("#footer");
+        const a = document.createElement("a");
+        a.setAttribute("name", "footer");
+        document.body.appendChild(a);
+
+        useScrollToHashAnchor();
+
+        expect(scrollSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("decodes percent-encoded ids before lookup", () => {
+        setLocationHash("#contact%20us");
+        const el = document.createElement("div");
+        el.id = "contact us";
+        document.body.appendChild(el);
+
+        useScrollToHashAnchor();
+
+        expect(scrollSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops observing after the timeout when the element never appears", async () => {
+        vi.useFakeTimers();
+        setLocationHash("#never");
+
+        useScrollToHashAnchor();
+        expect(scrollSpy).not.toHaveBeenCalled();
+
+        // Past the 5s safety timeout — observer should disconnect.
+        vi.advanceTimersByTime(6000);
+        vi.useRealTimers();
+
+        // Add the element after the timeout — observer is disconnected, so
+        // no scroll should fire.
+        const el = document.createElement("div");
+        el.id = "never";
+        document.body.appendChild(el);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(scrollSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/visualBuilder/eventManager/useScrollToHashAnchor.ts
+++ b/src/visualBuilder/eventManager/useScrollToHashAnchor.ts
@@ -1,0 +1,54 @@
+const SCROLL_TIMEOUT_MS = 5000;
+
+const findAnchor = (id: string): HTMLElement | null => {
+    const byId = document.getElementById(id);
+    if (byId) return byId;
+    try {
+        return document.querySelector<HTMLElement>(
+            `[name="${CSS.escape(id)}"]`
+        );
+    } catch {
+        return null;
+    }
+};
+
+export const useScrollToHashAnchor = (): void => {
+    const rawHash = window.location.hash;
+    if (!rawHash || rawHash.length < 2) return;
+    // Hash-router URLs (#/route, #!/route) are routes, not anchors.
+    if (rawHash.startsWith("#/") || rawHash.startsWith("#!/")) return;
+
+    let id: string;
+    try {
+        id = decodeURIComponent(rawHash.slice(1));
+    } catch {
+        id = rawHash.slice(1);
+    }
+    if (!id) return;
+
+    const scrollTo = (el: HTMLElement) => {
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+
+    const existing = findAnchor(id);
+    if (existing) {
+        scrollTo(existing);
+        return;
+    }
+
+    // User site may be an SPA — wait for the element to appear in the DOM.
+    const observer = new MutationObserver(() => {
+        const el = findAnchor(id);
+        if (el) {
+            observer.disconnect();
+            clearTimeout(timeoutId);
+            scrollTo(el);
+        }
+    });
+
+    const timeoutId = window.setTimeout(() => {
+        observer.disconnect();
+    }, SCROLL_TIMEOUT_MS);
+
+    observer.observe(document.body, { childList: true, subtree: true });
+};

--- a/src/visualBuilder/index.ts
+++ b/src/visualBuilder/index.ts
@@ -26,6 +26,7 @@ import initUI from "./components";
 import { useDraftFieldsPostMessageEvent } from "./eventManager/useDraftFieldsPostMessageEvent";
 import { useHideFocusOverlayPostMessageEvent } from "./eventManager/useHideFocusOverlayPostMessageEvent";
 import { useScrollToField } from "./eventManager/useScrollToField";
+import { useScrollToHashAnchor } from "./eventManager/useScrollToHashAnchor";
 import { debounceAddVariantFieldClass, getHighlightVariantFieldsStatus, setHighlightVariantFields, useVariantFieldsPostMessageEvent } from "./eventManager/useVariantsPostMessageEvent";
 import {
     generateEmptyBlocks,
@@ -363,6 +364,7 @@ export class VisualBuilder {
                         resizeObserver: this.resizeObserver,
                     });
                     useScrollToField();
+                    useScrollToHashAnchor();
                     useHighlightCommentIcon();
 
                     this.mutationObserver.observe(document.body, {
@@ -396,7 +398,7 @@ export class VisualBuilder {
                     );
 
 
-                    
+
                     useHideFocusOverlayPostMessageEvent({
                         overlayWrapper: this.overlayWrapper,
                         visualBuilderContainer: this.visualBuilderContainer,


### PR DESCRIPTION
## VB-1556: Scroll iframe to `#anchor` on initial load (Visual Builder)

Ticket: [VB-1556](https://contentstack.atlassian.net/browse/VB-1556)

Paired with: Visual Builder PR [contentstack/visual-builder#2234](https://github.com/contentstack/visual-builder/pull/2234)

### Why

When a user opens Visual Builder with a target URL containing a fragment (e.g. `host/page#footer`), the Visual Builder PR ensures the iframe `src` ends up as `host/page?entry_uid=…&builder=true#footer`. The browser, however, only attempts a native anchor scroll at *initial document parse time* — and for SPA target sites (the common case), the `#footer` element doesn't yet exist in the DOM at that instant. The browser's native scroll silently no-ops and never retries.

The fix has to live inside the iframe, which is what this SDK PR adds.

https://github.com/user-attachments/assets/36ea9451-e4a2-41e1-b7ac-767d341e6f40


### What this PR adds

1. **`src/visualBuilder/eventManager/useScrollToHashAnchor.ts`** (new file)
   - Reads `window.location.hash`.
   - Bails out for empty hashes and for hash-router URLs (`#/route`, `#!/route`) — those are routes, not anchors.
   - Decodes percent-encoded ids (e.g. `#contact%20us` → `contact us`).
   - Looks up the element via `document.getElementById(id)`, falling back to `document.querySelector('[name="…"]')` for legacy anchors.
   - If the element exists, calls `scrollIntoView({ behavior: "smooth", block: "start" })` immediately.
   - If it doesn't, sets up a `MutationObserver` on `document.body` (`childList`, `subtree`) so the scroll fires the moment the element is inserted (SPA hydration). A 5-second safety timeout disconnects the observer if the element never appears.

2. **`src/visualBuilder/index.ts`**
   - One import + one call to `useScrollToHashAnchor()` in the existing `BUILDER` window-type block of the `VisualBuilder` constructor, next to `useScrollToField()`.

### How it works end-to-end

```
1. Visual Editor sets iframe.src = "host/page?entry_uid=…&builder=true#footer"
2. Iframe loads; live-preview-sdk initializes inside it.
3. After the post-message init handshake, useScrollToHashAnchor() runs.
4. window.location.hash === "#footer" → not a router URL → look up #footer.
   a. Element present:    scrollIntoView immediately.
   b. Element not present (SPA, hydrating): MutationObserver waits up to 5s
      for it to appear, then scrollIntoView.
   c. Element never appears: observer is disconnected on timeout.
```

### Why scroll/parse logic lives inside the SDK and not in Visual Editor

Visual Editor is in a different window/context than the iframe. It cannot directly observe or scroll DOM nodes inside the user's page. The hook has to run in the same realm as the user's document — i.e. the SDK that's already bundled into that page.

### Why the `#fragment` is appended *after* the query string in the iframe URL

(Repeated here from the paired VE PR for reviewers landing on this one first.)

URL spec (RFC 3986): `scheme://host/path?query#fragment`. The fragment is always last.

If `#footer` were placed *before* `?entry_uid=…`, the `?` would become part of the fragment, breaking everything that reads `window.location.search` (this SDK, the user's analytics, their router) and native anchor scrolling (browser would look for `id="footer?entry_uid=…"`). The current order is the only standards-compliant one.

## Type of Change

- Feature
- Tests

## Testing

### Unit tests

Added `src/visualBuilder/eventManager/__test__/useScrollToHashAnchor.test.ts` covering:

- No hash present → no scroll.
- Hash-router `#/route` ignored.
- Hashbang `#!/route` ignored.
- Element already in DOM → `scrollIntoView` called immediately with `{ behavior: "smooth", block: "start" }`.
- Element appears later via mutation → observer fires → `scrollIntoView` called, observer disconnects.
- Legacy `<a name="…">` anchors found via fallback selector.
- Percent-encoded ids (`#contact%20us`) decoded before lookup.
- 5-second safety timeout disconnects observer; later DOM additions don't trigger scroll.

Run from `live-preview-sdk/`:

```bash
npx vitest run src/visualBuilder/eventManager/__test__/useScrollToHashAnchor.test.ts
```

All 8 tests pass.

### Manual testing

Verified against `test-resources/csr` (CSR SPA target site):

1. Open Visual Builder with a target URL containing `#footer` (after temporarily setting `id="footer"` on a footer-like element in the CSR app for local testing).
2. Page scrolls smoothly to the `#footer` element after entry load.
3. Reload preserves the anchor.
4. Hash-router targets (`#/dashboard`) are not affected — no spurious scroll.


[VB-1556]: https://contentstack.atlassian.net/browse/VB-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ