### PR TITLE
fix(visual-builder): keep overlayPropagation from piercing the SDK's own toolbar

### DIFF
--- a/src/visualBuilder/utils/__test__/getCsDataOfElement.test.ts
+++ b/src/visualBuilder/utils/__test__/getCsDataOfElement.test.ts
@@ -196,6 +196,38 @@ describe("getCsDataOfElement", () => {
             });
         });
 
+        test("does not pierce the visual builder's own UI (e.g. the field toolbar) even when fallback is enabled", () => {
+            Config.set("overlayPropagation", { enable: true });
+
+            // clicks on the SDK's own toolbar land on elements inside the
+            // visual builder container and must never resolve to the canvas
+            // field underneath
+            const vbContainer = document.createElement("div");
+            vbContainer.classList.add("visual-builder__container");
+            const toolbarButton = document.createElement("button");
+            vbContainer.appendChild(toolbarButton);
+            document.body.appendChild(vbContainer);
+
+            const toolbarClick = new MouseEvent("click", {
+                bubbles: true,
+                cancelable: true,
+                clientX: 100,
+                clientY: 100,
+            });
+            Object.defineProperty(toolbarClick, "target", {
+                value: toolbarButton,
+                writable: false,
+            });
+            (
+                document.elementsFromPoint as ReturnType<typeof vi.fn>
+            ).mockReturnValue([toolbarButton, vbContainer, cslpEl]);
+
+            const result = getCsDataOfElement(toolbarClick);
+
+            expect(result).toBeUndefined();
+            expect(document.elementsFromPoint).not.toHaveBeenCalled();
+        });
+
         test("returns undefined when fallback is enabled but no element under the cursor has data-cslp", () => {
             Config.set("overlayPropagation", { enable: true });
             const otherBlocker = document.createElement("div");

--- a/src/visualBuilder/utils/getCsDataOfElement.ts
+++ b/src/visualBuilder/utils/getCsDataOfElement.ts
@@ -28,7 +28,20 @@ export function getCsDataOfElement(
     let editableElement: Element | null =
         targetElement.closest("[data-cslp]");
 
-    if (!editableElement && Config.get().overlayPropagation.enable) {
+    // Clicks on the visual builder's own UI (field toolbar, overlays, add
+    // buttons) must never resolve to the canvas field underneath them. The
+    // elementsFromPoint fallback exists to pierce the website's own empty
+    // overlapping elements, not the SDK's chrome: piercing the toolbar made
+    // the edit (pencil) button double as a click on the field it covered.
+    const isVisualBuilderUi = targetElement.closest(
+        ".visual-builder__container"
+    );
+
+    if (
+        !editableElement &&
+        !isVisualBuilderUi &&
+        Config.get().overlayPropagation.enable
+    ) {
         const stack = document.elementsFromPoint(
             event.clientX,
             event.clientY

--- a/src/visualBuilder/utils/getCsDataOfElement.ts
+++ b/src/visualBuilder/utils/getCsDataOfElement.ts
@@ -33,14 +33,12 @@ export function getCsDataOfElement(
     // elementsFromPoint fallback exists to pierce the website's own empty
     // overlapping elements, not the SDK's chrome: piercing the toolbar made
     // the edit (pencil) button double as a click on the field it covered.
-    const isVisualBuilderUi = targetElement.closest(
-        ".visual-builder__container"
-    );
-
+    // The closest() check runs last so hover events only pay for it when
+    // the fallback is enabled and no field matched.
     if (
         !editableElement &&
-        !isVisualBuilderUi &&
-        Config.get().overlayPropagation.enable
+        Config.get().overlayPropagation.enable &&
+        !targetElement.closest(".visual-builder__container")
     ) {
         const stack = document.elementsFromPoint(
             event.clientX,


### PR DESCRIPTION
## Summary

With `overlayPropagation.enable` set, clicks that land on the visual builder's own UI (the field toolbar, overlays, add buttons) were resolved through `document.elementsFromPoint()` and could hit a `data-cslp` element rendered underneath the SDK's chrome.

In practice: when a page renders a heading from one entry directly above a rich text field from another entry, the focused field's toolbar sits on top of the heading. Clicking the toolbar's edit (pencil) button then also registered as a canvas click on the heading, because the SDK's capture-phase click listener runs before the button's own handler can stop propagation. That sent a focus event for the wrong entry while the edit modal opened for the right one, and the modal's Apply was lost.

## Changes

- `getCsDataOfElement` skips the `elementsFromPoint` fallback whenever the click target sits inside `.visual-builder__container`. The fallback exists to pierce the website's own empty overlapping elements (its original purpose, e.g. CSS grid spacer cells), never the SDK's own UI.

## Test plan

- New unit test: with `overlayPropagation` enabled, a click on an element inside the visual builder container does not resolve to the `data-cslp` element underneath, and `elementsFromPoint` is not called.
- Existing `getCsDataOfElement` and listener suites pass (30 tests).
- Manual: on a page where the field toolbar overlaps a neighboring field of a different entry, clicking the edit (pencil) button no longer flashes the underlying field's label, and the modal's Apply saves to the correct entry.
