### PR TITLE
release: promote develop_v4 to stage_v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -709,7 +709,6 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -732,10 +731,67 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/core/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.2",
@@ -1451,6 +1507,25 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1486,6 +1561,16 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.138.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+            "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1517,7 +1602,6 @@
             "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.0.0.tgz",
             "integrity": "sha512-wzx6YEXw2a+vKdE+p+XlIGsmH2bDjJzzevirtshT9ixoNIV2WJg83kG+QErPHs/ZkeR+MsqgRIFB6x22fDVRlg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@preact/signals-core": "^1.7.0"
             },
@@ -1537,6 +1621,270 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
             }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+            "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.59.0",
@@ -2012,6 +2360,25 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tybys/wasm-util/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/@types/aria-query": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2107,7 +2474,6 @@
             "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.19.0"
             }
@@ -2129,7 +2495,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
             "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -2520,7 +2885,6 @@
             "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
                 "@vitest/utils": "4.1.5",
@@ -2650,7 +3014,6 @@
             "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/utils": "4.1.5",
                 "fflate": "^0.8.2",
@@ -2688,7 +3051,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3331,7 +3693,6 @@
             "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -3419,8 +3780,7 @@
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "peer": true
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/dargs": {
             "version": "8.1.0",
@@ -3634,6 +3994,16 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/diff": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
@@ -3681,9 +4051,9 @@
             "dev": true
         },
         "node_modules/dompurify": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-            "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+            "version": "3.4.11",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+            "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -3956,7 +4326,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -4046,7 +4415,6 @@
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4510,17 +4878,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -4924,10 +5292,11 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -5667,10 +6036,20 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -5684,7 +6063,6 @@
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
             "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.1.0",
                 "data-urls": "^5.0.0",
@@ -5813,6 +6191,267 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/lilconfig": {
@@ -6262,9 +6901,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.15",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
             "dev": true,
             "funding": [
                 {
@@ -6716,9 +7355,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.12",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+            "version": "8.5.16",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
             "dev": true,
             "funding": [
                 {
@@ -6735,9 +7374,8 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -6750,7 +7388,6 @@
             "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
             "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -7120,6 +7757,40 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+            "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.138.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.1.4",
+                "@rolldown/binding-darwin-arm64": "1.1.4",
+                "@rolldown/binding-darwin-x64": "1.1.4",
+                "@rolldown/binding-freebsd-x64": "1.1.4",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+                "@rolldown/binding-linux-arm64-musl": "1.1.4",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+                "@rolldown/binding-linux-x64-gnu": "1.1.4",
+                "@rolldown/binding-linux-x64-musl": "1.1.4",
+                "@rolldown/binding-openharmony-arm64": "1.1.4",
+                "@rolldown/binding-wasm32-wasi": "1.1.4",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+                "@rolldown/binding-win32-x64-msvc": "1.1.4"
             }
         },
         "node_modules/rollup": {
@@ -7870,14 +8541,14 @@
             "dev": true
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -7910,7 +8581,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8203,7 +8873,6 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -8356,7 +9025,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
             "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8421,7 +9089,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.22.0.tgz",
             "integrity": "sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.22.0",
                 "@typescript-eslint/types": "8.22.0",
@@ -8639,19 +9306,17 @@
             "dev": true
         },
         "node_modules/vite": {
-            "version": "7.3.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+            "version": "8.1.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+            "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "esbuild": "^0.27.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.15"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.16",
+                "rolldown": "~1.1.3",
+                "tinyglobby": "^0.2.17"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -8667,9 +9332,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -8682,13 +9348,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -8714,31 +9383,12 @@
                 }
             }
         },
-        "node_modules/vite/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8752,7 +9402,6 @@
             "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.5",
                 "@vitest/mocker": "4.1.5",
@@ -9124,9 +9773,9 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.20.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/src/visualBuilder/components/__test__/startEditingButton.test.tsx
+++ b/src/visualBuilder/components/__test__/startEditingButton.test.tsx
@@ -110,6 +110,8 @@ describe("StartEditingButtonComponent", () => {
     test("should update href with current URL when mouse enters button", async () => {
         Object.defineProperty(window, "location", {
             value: new URL("http://localhost:3000"),
+            configurable: true,
+            writable: true,
         });
 
         const { getByTestId } = await asyncRender(
@@ -120,6 +122,7 @@ describe("StartEditingButtonComponent", () => {
 
         Object.defineProperty(window, "location", {
             value: new URL("http://localhost:3000/about"),
+            configurable: true,
             writable: true,
         });
 
@@ -135,6 +138,8 @@ describe("StartEditingButtonComponent", () => {
     test("should update href with current URL when button is focused", async () => {
         Object.defineProperty(window, "location", {
             value: new URL("http://localhost:3000"),
+            configurable: true,
+            writable: true,
         });
 
         const { getByTestId } = await asyncRender(
@@ -145,10 +150,11 @@ describe("StartEditingButtonComponent", () => {
 
         Object.defineProperty(window, "location", {
             value: new URL("http://localhost:3000/contact"),
+            configurable: true,
             writable: true,
         });
 
-        fireEvent.focus(button);
+        button.focus();
 
         const updatedHref = button.getAttribute("href");
         expect(updatedHref).not.toBe(initialHref);

--- a/src/visualBuilder/listeners/__test__/mouseClick.test.ts
+++ b/src/visualBuilder/listeners/__test__/mouseClick.test.ts
@@ -319,6 +319,7 @@ describe("handleBuilderInteraction — alt+click on anchor", () => {
             "noopener,noreferrer"
         );
         expect(window.location.href).toBe("");
+        openSpy.mockRestore();
     });
 
     it("resolves the anchor ancestor when the click lands on nested formatted text inside the link", async () => {
@@ -338,5 +339,33 @@ describe("handleBuilderInteraction — alt+click on anchor", () => {
 
         expect(preventDefaultSpy).toHaveBeenCalled();
         expect(window.location.href).toBe("https://example.com/bold-link");
+    });
+
+    it("blocks unsafe url schemes like javascript: on alt+click", async () => {
+        document.body.innerHTML = "";
+        const anchor = document.createElement("a");
+        anchor.href = "javascript:alert(1)";
+        document.body.appendChild(anchor);
+
+        const params = makeParams(anchor);
+        Object.defineProperty(params.event, "altKey", { value: true });
+
+        await handleBuilderInteraction(params);
+
+        expect(window.location.href).toBe("");
+    });
+
+    it("allows relative hrefs (resolve to the page's own http/https scheme)", async () => {
+        document.body.innerHTML = "";
+        const anchor = document.createElement("a");
+        anchor.href = "/other-entry";
+        document.body.appendChild(anchor);
+
+        const params = makeParams(anchor);
+        Object.defineProperty(params.event, "altKey", { value: true });
+
+        await handleBuilderInteraction(params);
+
+        expect(window.location.href).toBe(anchor.href);
     });
 });

--- a/src/visualBuilder/listeners/__test__/mouseClick.test.ts
+++ b/src/visualBuilder/listeners/__test__/mouseClick.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import handleBuilderInteraction from "../mouseClick";
 import { VisualBuilder } from "../../index";
 import { FieldSchemaMap } from "../../utils/fieldSchemaMap";
@@ -248,5 +248,95 @@ describe("handleBuilderInteraction — pauseFeedback guard", () => {
         await handleBuilderInteraction(makeParams(editableElement));
 
         expect(generateThread).toHaveBeenCalled();
+    });
+});
+
+describe("handleBuilderInteraction — alt+click on anchor", () => {
+    const originalLocation = window.location;
+
+    beforeEach(() => {
+        Object.defineProperty(window, "location", {
+            value: { href: "" },
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, "location", {
+            value: originalLocation,
+            writable: true,
+        });
+    });
+
+    it("prevents default/propagation and drives navigation itself instead of relying on the native click", async () => {
+        document.body.innerHTML = "";
+        const anchor = document.createElement("a");
+        anchor.href = "https://example.com/blog#anchor";
+        document.body.appendChild(anchor);
+
+        const params = makeParams(anchor);
+        Object.defineProperty(params.event, "altKey", { value: true });
+        const preventDefaultSpy = vi.spyOn(params.event, "preventDefault");
+        const stopPropagationSpy = vi.spyOn(params.event, "stopPropagation");
+
+        await handleBuilderInteraction(params);
+
+        expect(preventDefaultSpy).toHaveBeenCalled();
+        expect(stopPropagationSpy).toHaveBeenCalled();
+        expect(window.location.href).toBe("https://example.com/blog#anchor");
+        expect(getCsDataOfElement).not.toHaveBeenCalled();
+    });
+
+    it("does nothing on alt+click when the target isn't an anchor", async () => {
+        const editableElement = makeEditableElement();
+        const params = makeParams(editableElement);
+        Object.defineProperty(params.event, "altKey", { value: true });
+        const preventDefaultSpy = vi.spyOn(params.event, "preventDefault");
+
+        await handleBuilderInteraction(params);
+
+        expect(preventDefaultSpy).not.toHaveBeenCalled();
+        expect(window.location.href).toBe("");
+        expect(getCsDataOfElement).not.toHaveBeenCalled();
+    });
+
+    it("opens target=_blank links (RTE 'open in new tab') in a new tab instead of hijacking the iframe", async () => {
+        document.body.innerHTML = "";
+        const anchor = document.createElement("a");
+        anchor.href = "https://example.com/other-entry";
+        anchor.target = "_blank";
+        document.body.appendChild(anchor);
+
+        const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+        const params = makeParams(anchor);
+        Object.defineProperty(params.event, "altKey", { value: true });
+
+        await handleBuilderInteraction(params);
+
+        expect(openSpy).toHaveBeenCalledWith(
+            "https://example.com/other-entry",
+            "_blank",
+            "noopener,noreferrer"
+        );
+        expect(window.location.href).toBe("");
+    });
+
+    it("resolves the anchor ancestor when the click lands on nested formatted text inside the link", async () => {
+        document.body.innerHTML = "";
+        const anchor = document.createElement("a");
+        anchor.href = "https://example.com/bold-link";
+        const bold = document.createElement("strong");
+        bold.textContent = "click me";
+        anchor.appendChild(bold);
+        document.body.appendChild(anchor);
+
+        const params = makeParams(bold);
+        Object.defineProperty(params.event, "altKey", { value: true });
+        const preventDefaultSpy = vi.spyOn(params.event, "preventDefault");
+
+        await handleBuilderInteraction(params);
+
+        expect(preventDefaultSpy).toHaveBeenCalled();
+        expect(window.location.href).toBe("https://example.com/bold-link");
     });
 });

--- a/src/visualBuilder/listeners/mouseClick.ts
+++ b/src/visualBuilder/listeners/mouseClick.ts
@@ -84,7 +84,9 @@ export async function handleBuilderInteraction(
     params: HandleBuilderInteractionParams
 ): Promise<void> {
     const eventTarget = params.event.target as HTMLElement | null;
-    const isAnchorElement = eventTarget instanceof HTMLAnchorElement;
+    // resolve nearest anchor ancestor, not just an exact tag match
+    const anchorElement = eventTarget?.closest("a") ?? null;
+    const isAnchorElement = anchorElement !== null;
     const elementHasCslp =
         eventTarget &&
         (eventTarget.hasAttribute("data-cslp") ||
@@ -115,10 +117,20 @@ export async function handleBuilderInteraction(
         return;
     }
 
+    // Alt+click on a link: navigate explicitly, don't rely on the native
+    // click (browsers alt-click anchors as a download, not a navigation)
     if (params.event.altKey) {
-        if (isAnchorElement) {
+        if (anchorElement) {
+            const { href, target } = anchorElement;
             params.event.preventDefault();
             params.event.stopPropagation();
+            if (href) {
+                if (target === "_blank") {
+                    window.open(href, "_blank", "noopener,noreferrer");
+                } else {
+                    window.location.href = href;
+                }
+            }
         }
         return;
     }

--- a/src/visualBuilder/listeners/mouseClick.ts
+++ b/src/visualBuilder/listeners/mouseClick.ts
@@ -36,6 +36,8 @@ import { fetchEntryPermissionsAndStageDetails } from "../utils/fetchEntryPermiss
 import { isCustomFieldMultipleInstance } from "../utils/isCustomFieldMultipleInstance";
 import { getParentCslp, getWholeFieldElement } from "../utils/getWholeFieldElement";
 
+const SAFE_URL_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:"]);
+
 export type HandleBuilderInteractionParams = Omit<
     EventListenerHandlerParams,
     "eventDetails" | "customCursor"
@@ -121,10 +123,10 @@ export async function handleBuilderInteraction(
     // click (browsers alt-click anchors as a download, not a navigation)
     if (params.event.altKey) {
         if (anchorElement) {
-            const { href, target } = anchorElement;
+            const { href, target, protocol } = anchorElement;
             params.event.preventDefault();
             params.event.stopPropagation();
-            if (href) {
+            if (href && SAFE_URL_SCHEMES.has(protocol)) {
                 if (target === "_blank") {
                     window.open(href, "_blank", "noopener,noreferrer");
                 } else {

--- a/src/visualBuilder/listeners/mouseHover.ts
+++ b/src/visualBuilder/listeners/mouseHover.ts
@@ -303,21 +303,6 @@ const throttledMouseHover = throttle(async (params: HandleMouseHoverParams) => {
     }
 
     if (params.customCursor) {
-        const elementUnderCursor = document.elementFromPoint(
-            params.event.clientX,
-            params.event.clientY
-        );
-        if (elementUnderCursor) {
-            if (
-                elementUnderCursor.nodeName === "A" ||
-                elementUnderCursor.nodeName === "BUTTON"
-            ) {
-                elementUnderCursor.classList.add(
-                    visualBuilderStyles()["visual-builder__no-cursor-style"]
-                );
-            }
-        }
-
         if (config?.collab.enable && config?.collab.isFeedbackMode) {
             collabCustomCursor(params.customCursor);
             handleCursorPosition(params.event, params.customCursor);

--- a/src/visualBuilder/utils/__test__/getCsDataOfElement.test.ts
+++ b/src/visualBuilder/utils/__test__/getCsDataOfElement.test.ts
@@ -196,6 +196,38 @@ describe("getCsDataOfElement", () => {
             });
         });
 
+        test("does not pierce the visual builder's own UI (e.g. the field toolbar) even when fallback is enabled", () => {
+            Config.set("overlayPropagation", { enable: true });
+
+            // clicks on the SDK's own toolbar land on elements inside the
+            // visual builder container and must never resolve to the canvas
+            // field underneath
+            const vbContainer = document.createElement("div");
+            vbContainer.classList.add("visual-builder__container");
+            const toolbarButton = document.createElement("button");
+            vbContainer.appendChild(toolbarButton);
+            document.body.appendChild(vbContainer);
+
+            const toolbarClick = new MouseEvent("click", {
+                bubbles: true,
+                cancelable: true,
+                clientX: 100,
+                clientY: 100,
+            });
+            Object.defineProperty(toolbarClick, "target", {
+                value: toolbarButton,
+                writable: false,
+            });
+            (
+                document.elementsFromPoint as ReturnType<typeof vi.fn>
+            ).mockReturnValue([toolbarButton, vbContainer, cslpEl]);
+
+            const result = getCsDataOfElement(toolbarClick);
+
+            expect(result).toBeUndefined();
+            expect(document.elementsFromPoint).not.toHaveBeenCalled();
+        });
+
         test("returns undefined when fallback is enabled but no element under the cursor has data-cslp", () => {
             Config.set("overlayPropagation", { enable: true });
             const otherBlocker = document.createElement("div");

--- a/src/visualBuilder/utils/getCsDataOfElement.ts
+++ b/src/visualBuilder/utils/getCsDataOfElement.ts
@@ -28,7 +28,20 @@ export function getCsDataOfElement(
     let editableElement: Element | null =
         targetElement.closest("[data-cslp]");
 
-    if (!editableElement && Config.get().overlayPropagation.enable) {
+    // Clicks on the visual builder's own UI (field toolbar, overlays, add
+    // buttons) must never resolve to the canvas field underneath them. The
+    // elementsFromPoint fallback exists to pierce the website's own empty
+    // overlapping elements, not the SDK's chrome: piercing the toolbar made
+    // the edit (pencil) button double as a click on the field it covered.
+    const isVisualBuilderUi = targetElement.closest(
+        ".visual-builder__container"
+    );
+
+    if (
+        !editableElement &&
+        !isVisualBuilderUi &&
+        Config.get().overlayPropagation.enable
+    ) {
         const stack = document.elementsFromPoint(
             event.clientX,
             event.clientY

--- a/src/visualBuilder/utils/getCsDataOfElement.ts
+++ b/src/visualBuilder/utils/getCsDataOfElement.ts
@@ -33,14 +33,12 @@ export function getCsDataOfElement(
     // elementsFromPoint fallback exists to pierce the website's own empty
     // overlapping elements, not the SDK's chrome: piercing the toolbar made
     // the edit (pencil) button double as a click on the field it covered.
-    const isVisualBuilderUi = targetElement.closest(
-        ".visual-builder__container"
-    );
-
+    // The closest() check runs last so hover events only pay for it when
+    // the fallback is enabled and no field matched.
     if (
         !editableElement &&
-        !isVisualBuilderUi &&
-        Config.get().overlayPropagation.enable
+        Config.get().overlayPropagation.enable &&
+        !targetElement.closest(".visual-builder__container")
     ) {
         const stack = document.elementsFromPoint(
             event.clientX,

--- a/src/visualBuilder/visualBuilder.style.ts
+++ b/src/visualBuilder/visualBuilder.style.ts
@@ -699,6 +699,13 @@ export function visualBuilderStyles() {
         `,
         "visual-builder__default-cursor--disabled": css`
             cursor: none;
+            /* links/buttons carry their own cursor:pointer — suppress it too
+               while the custom cursor is active. Scoped to this body class so
+               it auto-reverts when the class is removed */
+            & a,
+            & button {
+                cursor: none !important;
+            }
         `,
         "visual-builder__draft-field": css`
             outline: 2px dashed #eb5646;
@@ -818,9 +825,6 @@ export function visualBuilderStyles() {
                 margin-top: 4px;
                 margin-bottom: 4px;
             }
-        `,
-        "visual-builder__no-cursor-style": css`
-            cursor: none !important;
         `,
         "visual-builder__field-toolbar-container": css`
             display: flex;


### PR DESCRIPTION
# develop_v4 → stage_v4

Promotes the latest fixes from `develop_v4` to `stage_v4` ahead of the next release.

## What's changed

### Fixes
- **Alt+click link navigation:** In-iframe links now navigate on alt+click instead of swallowing the click, restricted to safe URL schemes. Also fixes a leaked test spy.
- **Overlay propagation toolbar pierce:** The `overlayPropagation` flag no longer lets clicks pierce through the SDK's own toolbar; the own-UI guard is folded into the fallback condition.
- **RTE link cursor:** Cursor stays visible over RTE links in Visual Builder; npm audit vulnerabilities patched.

### Tests
- Coverage added for alt+click navigation (`mouseClick`), element data resolution (`getCsDataOfElement`), and the start-editing button.
