### PR TITLE
fix(VB-1797): match caret direction to text when inline editing

### DIFF
--- a/src/visualBuilder/utils/__test__/enableInlineEditing.test.ts
+++ b/src/visualBuilder/utils/__test__/enableInlineEditing.test.ts
@@ -127,6 +127,21 @@ describe("enableInlineEditing", () => {
         expect(editableElement.focus).toHaveBeenCalled();
     });
 
+    it("should set dir=auto so the caret follows the text direction", () => {
+        enableInlineEditing({
+            expectedFieldData: "Test content",
+            editableElement,
+            fieldType: FieldDataType.SINGLELINE,
+            elements: {
+                visualBuilderContainer,
+                resizeObserver,
+                lastEditedField: null,
+            },
+        });
+
+        expect(editableElement.getAttribute("dir")).toBe("auto");
+    });
+
     it("should handle multiline fields correctly", () => {
         enableInlineEditing({
             expectedFieldData: "Test content",

--- a/src/visualBuilder/utils/__test__/enableInlineEditing.test.ts
+++ b/src/visualBuilder/utils/__test__/enableInlineEditing.test.ts
@@ -142,6 +142,24 @@ describe("enableInlineEditing", () => {
         expect(editableElement.getAttribute("dir")).toBe("auto");
     });
 
+    it("should set dir=auto on the pseudo element when one is created", () => {
+        // Content differs from expected, so a pseudo editable element is used.
+        enableInlineEditing({
+            expectedFieldData: "Different content",
+            editableElement,
+            fieldType: FieldDataType.SINGLELINE,
+            elements: {
+                visualBuilderContainer,
+                resizeObserver,
+                lastEditedField: null,
+            },
+        });
+
+        const pseudoElement =
+            generatePseudoEditableElement.mock.results[0].value;
+        expect(pseudoElement.getAttribute("dir")).toBe("auto");
+    });
+
     it("should handle multiline fields correctly", () => {
         enableInlineEditing({
             expectedFieldData: "Test content",

--- a/src/visualBuilder/utils/__test__/getStyleOfAnElement.test.ts
+++ b/src/visualBuilder/utils/__test__/getStyleOfAnElement.test.ts
@@ -42,4 +42,14 @@ describe("getStyleOfAnElement", () => {
             width: "100px",
         });
     });
+
+    test("it should not copy direction/unicode-bidi so dir=auto can govern", () => {
+        const elem = document.createElement("div");
+        elem.style.direction = "rtl";
+        elem.style.unicodeBidi = "isolate";
+
+        const style = getStyleOfAnElement(elem);
+        expect(style).not.toHaveProperty("direction");
+        expect(style).not.toHaveProperty("unicode-bidi");
+    });
 });

--- a/src/visualBuilder/utils/enableInlineEditing.ts
+++ b/src/visualBuilder/utils/enableInlineEditing.ts
@@ -92,6 +92,9 @@ export function enableInlineEditing({
     }
 
     actualEditableField.setAttribute("contenteditable", "true");
+    // Let the caret follow the text's own direction so RTL content (e.g.
+    // Arabic, Hebrew) reads naturally instead of keeping an LTR caret.
+    actualEditableField.setAttribute("dir", "auto");
     actualEditableField.addEventListener("input", handleFieldInput);
     actualEditableField.addEventListener("keydown", handleFieldKeyDown);
 

--- a/src/visualBuilder/utils/enableInlineEditing.ts
+++ b/src/visualBuilder/utils/enableInlineEditing.ts
@@ -92,8 +92,7 @@ export function enableInlineEditing({
     }
 
     actualEditableField.setAttribute("contenteditable", "true");
-    // Let the caret follow the text's own direction so RTL content (e.g.
-    // Arabic, Hebrew) reads naturally instead of keeping an LTR caret.
+    // caret follows the text direction (fixes LTR caret on RTL content)
     actualEditableField.setAttribute("dir", "auto");
     actualEditableField.addEventListener("input", handleFieldInput);
     actualEditableField.addEventListener("keydown", handleFieldKeyDown);

--- a/src/visualBuilder/utils/getStyleOfAnElement.ts
+++ b/src/visualBuilder/utils/getStyleOfAnElement.ts
@@ -30,6 +30,9 @@ export default function getStyleOfAnElement(element: HTMLElement): {
         "margin-bottom",
         "-webkit-user-modify",
         "cursor",
+        // let the pseudo element's dir="auto" decide direction, not inline copies
+        "direction",
+        "unicode-bidi",
     ];
 
     const styles: { [key: string]: string } = {};

--- a/src/visualBuilder/utils/handleIndividualFields.ts
+++ b/src/visualBuilder/utils/handleIndividualFields.ts
@@ -133,6 +133,7 @@ export function cleanIndividualFieldResidual(elements: {
             VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY
         );
         previousSelectedEditableDOM.removeAttribute("contenteditable");
+        previousSelectedEditableDOM.removeAttribute("dir");
         previousSelectedEditableDOM.removeEventListener(
             "input",
             handleFieldInput


### PR DESCRIPTION
## What

Inline-editable text fields kept a left-to-right caret even when the field held right-to-left content (Arabic, Hebrew). The glyphs rendered in the correct RTL order, but the caret stayed on the LTR side and did not follow where characters were being inserted, so editing RTL text was awkward.

## Change

- Set `dir="auto"` on the editable element when inline editing turns on. The browser then picks the writing direction from the content's first strong character, so the caret matches the text.
- Remove the attribute on teardown, next to the existing `contenteditable` cleanup, so nothing is left on the host element.

## Notes

- Direction is content-driven. An empty RTL field starts LTR until the first strong character is typed, then switches.
- Added a unit test that checks the attribute is set on an editable field.

## Testing

- `npx vitest run` for the affected utils passes.
- Still needs a manual check in an RTL locale entry once this build is picked up by the canvas.

Jira: [VB-1797](https://contentstack.atlassian.net/browse/VB-1797)


[VB-1797]: https://contentstack.atlassian.net/browse/VB-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ