### PR TITLE
fix(security): bump dompurify to patch XSS and prototype pollution issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "classnames": "^2.5.1",
                 "dayjs": "^1.11.13",
                 "deepsignal": "^1.5.0",
-                "dompurify": "^3.4.1",
+                "dompurify": "^3.4.12",
                 "get-xpath": "^3.2.0",
                 "goober": "^2.1.16",
                 "lodash-es": "^4.18.1",
@@ -3681,9 +3681,9 @@
             "dev": true
         },
         "node_modules/dompurify": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-            "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "classnames": "^2.5.1",
         "dayjs": "^1.11.13",
         "deepsignal": "^1.5.0",
-        "dompurify": "^3.4.1",
+        "dompurify": "^3.4.12",
         "get-xpath": "^3.2.0",
         "goober": "^2.1.16",
         "lodash-es": "^4.18.1",


### PR DESCRIPTION
## What was the vulnerability

Our pinned `dompurify` version (`^3.4.1`) is affected by several sanitization-bypass (XSS) and prototype-pollution advisories fixed in later 3.4.x patch releases (e.g. a sanitization bypass fixed in 3.4.5, and follow-up hardening in subsequent patches). `dompurify` is used throughout the SDK to sanitize HTML before rendering, so a bypass in the sanitizer undermines that protection.

## What the fix does

Bumps the `dompurify` dependency from `^3.4.1` to `^3.4.12` (the latest 3.4.x release) in `package.json` and regenerates the corresponding lockfile entry. No code changes were needed — this is a drop-in patch-level upgrade within the same major version.

## How it was verified

- Confirmed `3.4.12` is the latest published 3.4.x release on the npm registry.
- Confirmed the version bump is contained to the `dompurify` entries in `package.json` / `package-lock.json` with no other lockfile drift.
- No new dependency was introduced; `dompurify` was already a direct dependency.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCrxpDvgDgFAVc8bxeFto6)_