### PR TITLE
chore: update CODEOWNERS to visual-preview-developers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @contentstack/ghost-pr-reviewers @contentstack/visual-preview-developers
+* @contentstack/visual-preview-developers
 
 .github/workflows/sca-scan.yml @contentstack/security-admin
 


### PR DESCRIPTION
## Summary

Updates CODEOWNERS to make `@contentstack/visual-preview-developers` the owning team.

## Changes

- Removed `@contentstack/ghost-pr-reviewers` from the `*` owner line; `@contentstack/visual-preview-developers` remains. Security-admin entries are unchanged.

## Test plan

- CODEOWNERS syntax unchanged apart from removing one team; review requests will go to `visual-preview-developers` only once merged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
