### PR TITLE
feat(visual-builder): normalize multiline value on SYNC_FIELD for on-type canvas save

### DIFF
--- a/src/visualBuilder/generators/__test__/generateOverlay.test.ts
+++ b/src/visualBuilder/generators/__test__/generateOverlay.test.ts
@@ -57,5 +57,58 @@ describe("sendFieldEvent", () => {
         expect(FieldSchemaMap.getFieldSchema).not.toHaveBeenCalled();
         expect(visualBuilderPostMessage?.send).not.toHaveBeenCalled();
     });
-});
 
+    const setupMultilineField = () => {
+        previousSelectedEditableDOM.setAttribute(
+            "data-cslp",
+            "content_type.entry.field"
+        );
+        previousSelectedEditableDOM.innerHTML = "line1<br>line2";
+        const innerTextSetter = vi.fn();
+        Object.defineProperty(previousSelectedEditableDOM, "innerText", {
+            configurable: true,
+            get: () => "line1\nline2",
+            set: innerTextSetter,
+        });
+        vi.mocked(FieldSchemaMap.getFieldSchema).mockResolvedValue({
+            display_name: "Multi",
+            data_type: "text",
+            field_metadata: { multiline: true },
+        } as any);
+        return innerTextSetter;
+    };
+
+    it("normalizes a multiline value for the on-type SYNC_FIELD without rewriting the editable DOM", async () => {
+        const innerTextSetter = setupMultilineField();
+
+        sendFieldEvent({
+            visualBuilderContainer,
+            eventType: VisualBuilderPostMessageEvents.SYNC_FIELD,
+        });
+
+        await vi.waitFor(() =>
+            expect(visualBuilderPostMessage?.send).toHaveBeenCalledWith(
+                VisualBuilderPostMessageEvents.SYNC_FIELD,
+                expect.objectContaining({ data: "line1\nline2" })
+            )
+        );
+        expect(innerTextSetter).not.toHaveBeenCalled();
+    });
+
+    it("rewrites the editable DOM with the normalized value on the commit UPDATE_FIELD", async () => {
+        const innerTextSetter = setupMultilineField();
+
+        sendFieldEvent({
+            visualBuilderContainer,
+            eventType: VisualBuilderPostMessageEvents.UPDATE_FIELD,
+        });
+
+        await vi.waitFor(() =>
+            expect(visualBuilderPostMessage?.send).toHaveBeenCalledWith(
+                VisualBuilderPostMessageEvents.UPDATE_FIELD,
+                expect.objectContaining({ data: "line1\nline2" })
+            )
+        );
+        expect(innerTextSetter).toHaveBeenCalledWith("line1\nline2");
+    });
+});

--- a/src/visualBuilder/generators/generateOverlay.tsx
+++ b/src/visualBuilder/generators/generateOverlay.tsx
@@ -189,15 +189,17 @@ export function sendFieldEvent(options: ISendFieldEventParams): void {
             fieldMetadata.fieldPath
         )
             .then((fieldSchema) => {
-                if (
-                    fieldSchema &&
-                    eventType === VisualBuilderPostMessageEvents.UPDATE_FIELD
-                ) {
+                if (fieldSchema) {
                     const fieldType = getFieldType(fieldSchema);
                     if (fieldType && fieldType === FieldDataType.MULTILINE) {
                         data = getMultilinePlaintext(actualEditedElement);
-                        (actualEditedElement as HTMLElement).innerText =
-                            data as string;
+                        if (
+                            eventType ===
+                            VisualBuilderPostMessageEvents.UPDATE_FIELD
+                        ) {
+                            (actualEditedElement as HTMLElement).innerText =
+                                data as string;
+                        }
                     }
                 }
             })


### PR DESCRIPTION
## Title

Normalize multiline value on SYNC_FIELD for on-type canvas save

## Description

When Visual Builder saves canvas edits on type, a multiline field now sends a normalized plaintext value on the `SYNC_FIELD` event, matching what the commit `UPDATE_FIELD` sends. Previously only the commit path normalized the value, so an on-type save could persist raw editable markup for multiline fields.

The editable DOM is rewritten with the normalized value only on `UPDATE_FIELD` (the commit), not on `SYNC_FIELD`. Rewriting on every keystroke would move the caret, so on-type editing stays caret-safe while still sending the correct plaintext.

Base is `feat/canvas-field-lock` (stacked). Pairs with the Visual Builder change that persists canvas edits on type.

## Type of Change

- [x] Feature

## Testing

Unit tests in `generateOverlay.test.ts` cover both paths: the multiline value is normalized on the on-type `SYNC_FIELD` without rewriting the editable DOM, and the editable DOM is rewritten with the normalized value on the commit `UPDATE_FIELD`. Run: `npx vitest run src/visualBuilder/generators/__test__/generateOverlay.test.ts`. All pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
