### PR TITLE
feat(VB-2055): add isVisualEditorEditing helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import LightLivePreviewHoC from "./light-sdk";
 
 export type IStackSdk = ExternalStackSdkType;
 
-
 const ContentstackLivePreview =
     typeof process !== "undefined" &&
     (process?.env?.PURGE_PREVIEW_SDK === "true" ||
@@ -14,4 +13,7 @@ const ContentstackLivePreview =
         : ContentstackLivePreviewHOC;
 
 export const VB_EmptyBlockParentClass = "visual-builder__empty-block-parent";
+
+export { isVisualEditorEditing } from "./visualBuilder/utils/editingState";
+
 export default ContentstackLivePreview;

--- a/src/visualBuilder/utils/__test__/editingState.test.ts
+++ b/src/visualBuilder/utils/__test__/editingState.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { isVisualEditorEditing } from "../editingState";
+
+const ATTR = "data-cslp-field-type";
+
+describe("isVisualEditorEditing", () => {
+    let el: HTMLElement;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        el = document.createElement("div");
+        document.body.appendChild(el);
+    });
+
+    it("returns false when nothing is being edited", () => {
+        expect(isVisualEditorEditing()).toBe(false);
+        expect(isVisualEditorEditing(el)).toBe(false);
+    });
+
+    it("returns true when a descendant of the element is being edited", () => {
+        const child = document.createElement("span");
+        el.appendChild(child);
+        child.setAttribute(ATTR, "singleline");
+
+        expect(isVisualEditorEditing(el)).toBe(true);
+    });
+
+    it("returns true when the element itself carries the attribute", () => {
+        el.setAttribute(ATTR, "singleline");
+        expect(isVisualEditorEditing(el)).toBe(true);
+    });
+
+    it("scopes the check to the given element", () => {
+        const other = document.createElement("div");
+        document.body.appendChild(other);
+        const child = document.createElement("span");
+        other.appendChild(child);
+        child.setAttribute(ATTR, "singleline");
+
+        expect(isVisualEditorEditing(el)).toBe(false);
+        expect(isVisualEditorEditing(other)).toBe(true);
+    });
+
+    it("checks the whole document when no element is passed", () => {
+        expect(isVisualEditorEditing()).toBe(false);
+        el.setAttribute(ATTR, "singleline");
+        expect(isVisualEditorEditing()).toBe(true);
+    });
+
+    describe("without a DOM (SSR)", () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it("returns false", () => {
+            vi.stubGlobal("document", undefined);
+            expect(isVisualEditorEditing()).toBe(false);
+        });
+    });
+});

--- a/src/visualBuilder/utils/editingState.ts
+++ b/src/visualBuilder/utils/editingState.ts
@@ -1,0 +1,22 @@
+import { VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY } from "./constants";
+
+const EDITING_SELECTOR = `[${VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY}]`;
+
+/**
+ * Returns whether a field inside `element` is being edited in Visual Editor.
+ * Pass the element wrapping your self-updating content to pause it while true.
+ * Omit `element` to check the whole document. Returns `false` during SSR.
+ */
+export function isVisualEditorEditing(element?: HTMLElement | null): boolean {
+    if (typeof document === "undefined") return false;
+
+    if (element) {
+        return (
+            (typeof element.matches === "function" &&
+                element.matches(EDITING_SELECTOR)) ||
+            element.querySelector(EDITING_SELECTOR) !== null
+        );
+    }
+
+    return document.querySelector(EDITING_SELECTOR) !== null;
+}


### PR DESCRIPTION
## Summary

Adds `isVisualEditorEditing(element)`, a small helper that tells a site whether a field is currently being edited in Visual Editor. Sites can use it to pause self-updating content (CSS animations, carousels, polled or streamed data) while an author edits, then resume afterwards. Without it, such content keeps mutating the DOM under the editor and the edit form resyncs to a moving target.

## Changes

- `src/visualBuilder/utils/editingState.ts` — new `isVisualEditorEditing(element?)`. Returns `true` while `element` (or a descendant) carries the existing `data-cslp-field-type` marker the SDK already sets on the focused field; `false` otherwise. Pass an element to scope the check, or omit it to check the whole document.
- `src/index.ts` — export the helper from the package entry.
- Unit tests for the helper (element scoping, document-wide, SSR).

https://github.com/user-attachments/assets/8bd1a125-2607-4a38-ab12-24b2fce8e64b

Notes:
- Side-effect-free: a plain check with no observer or subscription to manage. The consumer decides how to read it (interval, animation loop, framework effect, on demand).
- SSR-safe: returns `false` when there is no DOM.
- Purely additive and backward compatible: a new named export with no runtime side effects, so it tree-shakes out for consumers that do not use it. It relies only on the pre-existing attribute, so it also works for sites on older SDK versions.

## Test plan

- New `editingState` unit tests pass (6): false when idle, true for a descendant edit, true when the element itself is the marker, scoped-to-element, document-wide, and SSR no-op.
- `tsc --noEmit` clean; lint clean.
- Verified in a sample app: a 3s slideshow and a continuously scrolling feed pause while their fields are edited in Visual Editor and resume on blur, with no effect outside Visual Editor.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
