### PR TITLE
fix: isolate goober pragma from host app to prevent react-hot-toast crash

### DIFF
--- a/src/visualBuilder/index.ts
+++ b/src/visualBuilder/index.ts
@@ -19,9 +19,7 @@ import { resolvePageContext } from "./utils/resolvePageContext";
 import visualBuilderPostMessage from "./utils/visualBuilderPostMessage";
 import { VisualBuilderPostMessageEvents } from "./utils/types/postMessage.types";
 
-import { setup } from "goober";
 import { debounce, isEqual } from "lodash-es";
-import { h } from "preact";
 import { extractDetailsFromCslp, isValidCslp } from "../cslp";
 import initUI from "./components";
 import { useDraftFieldsPostMessageEvent } from "./eventManager/useDraftFieldsPostMessageEvent";
@@ -288,9 +286,6 @@ export class VisualBuilder {
         initUI({
             resizeObserver: this.resizeObserver,
         });
-
-        // Initializing goober for css-in-js
-        setup(h);
 
         this.visualBuilderContainer = document.querySelector(
             ".visual-builder__container"


### PR DESCRIPTION
## What

Visual Builder called goober's `setup(h)` with Preact's `h` during init. `setup()` sets goober's **global, shared** element pragma. Because goober is a singleton hoisted across the host app's dependency tree, this flips the pragma for every goober consumer in the page, not just the SDK.

A host app that pairs the SDK with a goober-backed UI library such as `react-hot-toast` then renders through that Preact pragma. On React 19 the emitted elements carry the legacy element brand and React rejects them:

```
A React Element from an older version of React was rendered. This is not supported.
```

The result is a white screen the moment a toast (or any goober `styled` component) mounts, only inside Live Preview / Visual Builder.

## Fix

Remove the `setup(h)` call and its now-unused `setup` / `h` imports.

The SDK only uses goober's `css`, `glob`, and `keyframes`, none of which read the pragma. It never uses `styled`, the sole consumer of the pragma. So `setup(h)` did nothing for the SDK's own styling and only leaked Preact's `h` into the host's shared goober instance. Removing it restores the pragma-free behavior the SDK used before this call was added, and stops the SDK from touching host-app goober state at all.

## Why it is safe

- No `styled` usage anywhere in the SDK source (the only API that needs the pragma).
- `css` / `glob` / `keyframes` compute class names and inject sheets without the pragma.
- No `extractCss` usage; no `css()` called with a function argument (the only path that reads context props).
- The style functions the SDK does use worked without `setup` before this call existed.

## Testing

- Reproduced the crash in a standalone Next.js 15 + React 19 + react-hot-toast app (single hoisted goober), then confirmed the built change makes the crash disappear. A pragma probe shows the goober element brand stays on React 19's `Symbol(react.transitional.element)` before and after SDK init, instead of flipping to `Symbol(react.element)`.
- `npm run build` passes.
- Full Visual Builder, edit-button, and timeline test suites pass (106 tests), including hover/overlay tests that render field outlines and cursors via goober `css`, confirming styling still works.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
