### PR TITLE
develop to stage 6 aug release

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import LightLivePreviewHoC from "./light-sdk";
 
 export type IStackSdk = ExternalStackSdkType;
 
-
 const ContentstackLivePreview =
     typeof process !== "undefined" &&
     (process?.env?.PURGE_PREVIEW_SDK === "true" ||
@@ -14,4 +13,7 @@ const ContentstackLivePreview =
         : ContentstackLivePreviewHOC;
 
 export const VB_EmptyBlockParentClass = "visual-builder__empty-block-parent";
+
+export { isVisualEditorEditing } from "./visualBuilder/utils/editingState";
+
 export default ContentstackLivePreview;

--- a/src/visualBuilder/index.ts
+++ b/src/visualBuilder/index.ts
@@ -19,9 +19,7 @@ import { resolvePageContext } from "./utils/resolvePageContext";
 import visualBuilderPostMessage from "./utils/visualBuilderPostMessage";
 import { VisualBuilderPostMessageEvents } from "./utils/types/postMessage.types";
 
-import { setup } from "goober";
 import { debounce, isEqual } from "lodash-es";
-import { h } from "preact";
 import { extractDetailsFromCslp, isValidCslp } from "../cslp";
 import initUI from "./components";
 import { useDraftFieldsPostMessageEvent } from "./eventManager/useDraftFieldsPostMessageEvent";
@@ -288,9 +286,6 @@ export class VisualBuilder {
         initUI({
             resizeObserver: this.resizeObserver,
         });
-
-        // Initializing goober for css-in-js
-        setup(h);
 
         this.visualBuilderContainer = document.querySelector(
             ".visual-builder__container"

--- a/src/visualBuilder/utils/__test__/editingState.test.ts
+++ b/src/visualBuilder/utils/__test__/editingState.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { isVisualEditorEditing } from "../editingState";
+
+const ATTR = "data-cslp-field-type";
+
+describe("isVisualEditorEditing", () => {
+    let el: HTMLElement;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        el = document.createElement("div");
+        document.body.appendChild(el);
+    });
+
+    it("returns false when nothing is being edited", () => {
+        expect(isVisualEditorEditing()).toBe(false);
+        expect(isVisualEditorEditing(el)).toBe(false);
+    });
+
+    it("returns true when a descendant of the element is being edited", () => {
+        const child = document.createElement("span");
+        el.appendChild(child);
+        child.setAttribute(ATTR, "singleline");
+
+        expect(isVisualEditorEditing(el)).toBe(true);
+    });
+
+    it("returns true when the element itself carries the attribute", () => {
+        el.setAttribute(ATTR, "singleline");
+        expect(isVisualEditorEditing(el)).toBe(true);
+    });
+
+    it("scopes the check to the given element", () => {
+        const other = document.createElement("div");
+        document.body.appendChild(other);
+        const child = document.createElement("span");
+        other.appendChild(child);
+        child.setAttribute(ATTR, "singleline");
+
+        expect(isVisualEditorEditing(el)).toBe(false);
+        expect(isVisualEditorEditing(other)).toBe(true);
+    });
+
+    it("checks the whole document when no element is passed", () => {
+        expect(isVisualEditorEditing()).toBe(false);
+        el.setAttribute(ATTR, "singleline");
+        expect(isVisualEditorEditing()).toBe(true);
+    });
+
+    describe("without a DOM (SSR)", () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it("returns false", () => {
+            vi.stubGlobal("document", undefined);
+            expect(isVisualEditorEditing()).toBe(false);
+        });
+    });
+});

--- a/src/visualBuilder/utils/__test__/enableInlineEditing.test.ts
+++ b/src/visualBuilder/utils/__test__/enableInlineEditing.test.ts
@@ -127,6 +127,21 @@ describe("enableInlineEditing", () => {
         expect(editableElement.focus).toHaveBeenCalled();
     });
 
+    it("should set dir=auto so the caret follows the text direction", () => {
+        enableInlineEditing({
+            expectedFieldData: "Test content",
+            editableElement,
+            fieldType: FieldDataType.SINGLELINE,
+            elements: {
+                visualBuilderContainer,
+                resizeObserver,
+                lastEditedField: null,
+            },
+        });
+
+        expect(editableElement.getAttribute("dir")).toBe("auto");
+    });
+
     it("should handle multiline fields correctly", () => {
         enableInlineEditing({
             expectedFieldData: "Test content",

--- a/src/visualBuilder/utils/__test__/enableInlineEditing.test.ts
+++ b/src/visualBuilder/utils/__test__/enableInlineEditing.test.ts
@@ -142,6 +142,24 @@ describe("enableInlineEditing", () => {
         expect(editableElement.getAttribute("dir")).toBe("auto");
     });
 
+    it("should set dir=auto on the pseudo element when one is created", () => {
+        // Content differs from expected, so a pseudo editable element is used.
+        enableInlineEditing({
+            expectedFieldData: "Different content",
+            editableElement,
+            fieldType: FieldDataType.SINGLELINE,
+            elements: {
+                visualBuilderContainer,
+                resizeObserver,
+                lastEditedField: null,
+            },
+        });
+
+        const pseudoElement =
+            generatePseudoEditableElement.mock.results[0].value;
+        expect(pseudoElement.getAttribute("dir")).toBe("auto");
+    });
+
     it("should handle multiline fields correctly", () => {
         enableInlineEditing({
             expectedFieldData: "Test content",

--- a/src/visualBuilder/utils/__test__/getStyleOfAnElement.test.ts
+++ b/src/visualBuilder/utils/__test__/getStyleOfAnElement.test.ts
@@ -42,4 +42,14 @@ describe("getStyleOfAnElement", () => {
             width: "100px",
         });
     });
+
+    test("it should not copy direction/unicode-bidi so dir=auto can govern", () => {
+        const elem = document.createElement("div");
+        elem.style.direction = "rtl";
+        elem.style.unicodeBidi = "isolate";
+
+        const style = getStyleOfAnElement(elem);
+        expect(style).not.toHaveProperty("direction");
+        expect(style).not.toHaveProperty("unicode-bidi");
+    });
 });

--- a/src/visualBuilder/utils/editingState.ts
+++ b/src/visualBuilder/utils/editingState.ts
@@ -1,0 +1,22 @@
+import { VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY } from "./constants";
+
+const EDITING_SELECTOR = `[${VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY}]`;
+
+/**
+ * Returns whether a field inside `element` is being edited in Visual Editor.
+ * Pass the element wrapping your self-updating content to pause it while true.
+ * Omit `element` to check the whole document. Returns `false` during SSR.
+ */
+export function isVisualEditorEditing(element?: HTMLElement | null): boolean {
+    if (typeof document === "undefined") return false;
+
+    if (element) {
+        return (
+            (typeof element.matches === "function" &&
+                element.matches(EDITING_SELECTOR)) ||
+            element.querySelector(EDITING_SELECTOR) !== null
+        );
+    }
+
+    return document.querySelector(EDITING_SELECTOR) !== null;
+}

--- a/src/visualBuilder/utils/enableInlineEditing.ts
+++ b/src/visualBuilder/utils/enableInlineEditing.ts
@@ -92,6 +92,9 @@ export function enableInlineEditing({
     }
 
     actualEditableField.setAttribute("contenteditable", "true");
+    // Let the caret follow the text's own direction so RTL content (e.g.
+    // Arabic, Hebrew) reads naturally instead of keeping an LTR caret.
+    actualEditableField.setAttribute("dir", "auto");
     actualEditableField.addEventListener("input", handleFieldInput);
     actualEditableField.addEventListener("keydown", handleFieldKeyDown);
 

--- a/src/visualBuilder/utils/enableInlineEditing.ts
+++ b/src/visualBuilder/utils/enableInlineEditing.ts
@@ -92,8 +92,7 @@ export function enableInlineEditing({
     }
 
     actualEditableField.setAttribute("contenteditable", "true");
-    // Let the caret follow the text's own direction so RTL content (e.g.
-    // Arabic, Hebrew) reads naturally instead of keeping an LTR caret.
+    // caret follows the text direction (fixes LTR caret on RTL content)
     actualEditableField.setAttribute("dir", "auto");
     actualEditableField.addEventListener("input", handleFieldInput);
     actualEditableField.addEventListener("keydown", handleFieldKeyDown);

--- a/src/visualBuilder/utils/getStyleOfAnElement.ts
+++ b/src/visualBuilder/utils/getStyleOfAnElement.ts
@@ -30,6 +30,9 @@ export default function getStyleOfAnElement(element: HTMLElement): {
         "margin-bottom",
         "-webkit-user-modify",
         "cursor",
+        // let the pseudo element's dir="auto" decide direction, not inline copies
+        "direction",
+        "unicode-bidi",
     ];
 
     const styles: { [key: string]: string } = {};

--- a/src/visualBuilder/utils/handleIndividualFields.ts
+++ b/src/visualBuilder/utils/handleIndividualFields.ts
@@ -133,6 +133,7 @@ export function cleanIndividualFieldResidual(elements: {
             VISUAL_BUILDER_FIELD_TYPE_ATTRIBUTE_KEY
         );
         previousSelectedEditableDOM.removeAttribute("contenteditable");
+        previousSelectedEditableDOM.removeAttribute("dir");
         previousSelectedEditableDOM.removeEventListener(
             "input",
             handleFieldInput


### PR DESCRIPTION
## What

Release candidate merge of `develop_v4` into `stage_v4` for the 6 Aug release. It carries three changes that landed on `develop_v4` after v4.4.5.

Tickets: VB-1797, VB-2055

## Changes

### RTL caret direction while inline editing (VB-1797)

Inline-editable fields kept a left-to-right caret even when the field held right-to-left content (Arabic, Hebrew). Glyphs rendered in the correct order, but the caret stayed on the LTR side and did not follow where characters were being inserted.

- `enableInlineEditing.ts`: set `dir="auto"` on the editable element, so the browser derives writing direction from the content's first strong character.
- `handleIndividualFields.ts`: remove the attribute on teardown, next to the existing `contenteditable` cleanup, so nothing is left behind on the host element.
- `getStyleOfAnElement.ts`: exclude `direction` and `unicode-bidi` from the styles copied onto the pseudo editable element. Those inline copies were overriding `dir="auto"` on the truncated/mismatched-content path, so the caret stayed LTR there even after the first fix.

Direction is content-driven, so an empty RTL field starts LTR and switches once the first strong character is typed.

Came in via #620 plus a follow-up commit for the pseudo element path.

### `isVisualEditorEditing()` helper (VB-2055)

Sites whose content updates on its own (CSS animations, carousels, polled or streamed data) kept mutating the DOM while an author was editing, so the quick form resynced to a moving target.

- `src/visualBuilder/utils/editingState.ts`: new `isVisualEditorEditing(element?)`. Returns `true` while `element` or one of its descendants carries the `data-cslp-field-type` marker the SDK already sets on the focused field. Omit the argument to check the whole document.
- `src/index.ts`: export it from the package entry.

It is a plain check with no observer or subscription, and it returns `false` when there is no DOM, so SSR is safe. Purely additive: a new named export with no runtime side effects, and it reads an attribute that already existed, so it also works for sites on older SDK versions.

Came in via #629.

### goober pragma no longer leaks into the host app

`VisualBuilder` called goober's `setup(h)` with Preact's `h` during init. `setup()` sets goober's global, shared element pragma, and goober is usually hoisted to a single instance in the host's dependency tree, so this flipped the pragma for every goober consumer on the page. A host app using a goober-backed library such as `react-hot-toast` then rendered through the Preact pragma and React 19 rejected the elements with "A React Element from an older version of React was rendered", giving a white screen as soon as a toast mounted.

The SDK only uses goober's `css`, `glob`, and `keyframes`, none of which read the pragma, and it never uses `styled`, the only API that does. Removing the call restores the behavior the SDK had before it was added.

Came in via #630.

## Release notes

No version bump in this PR. `package.json` stays at 4.4.5 on both branches; the bump and CHANGELOG regeneration happen on the `stage_v4` to `main` release PR.

## Testing

- Unit tests for all three changes: new `editingState` suite (6 cases covering idle, descendant edit, element itself, element scoping, document-wide, SSR), `dir="auto"` assertions on both the direct and pseudo editable element in `enableInlineEditing`, and a `getStyleOfAnElement` case asserting `direction` and `unicode-bidi` are not copied.
- The goober change was verified against a standalone Next.js 15 + React 19 + react-hot-toast app: the crash reproduces before and disappears after, and the goober element brand stays on React 19's `Symbol(react.transitional.element)` across SDK init. Visual Builder, edit-button, and timeline suites pass, including the hover and overlay tests that style through goober `css`.
- RTL editing still needs a manual pass in an RTL locale entry on the canvas build.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
